### PR TITLE
Merge stream in copy-assets to support async

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -223,52 +223,70 @@ gulp.task('clean-source', function () {
 // gulp copy-assets.
 // Copy all needed dependency assets files from bower_component assets to themes /js, /scss and /fonts folder. Run this task after bower install or bower update
 
-////////////////// All Bootstrap SASS  Assets /////////////////////////
 gulp.task('copy-assets', ['clean-source'], function() {
 
-////////////////// All Bootstrap 4 Assets /////////////////////////
-// Copy all JS files
+    var streams = [];
 
-    var stream = gulp.src(basePaths.node + 'bootstrap/dist/js/**/*.js')
-       .pipe(gulp.dest(basePaths.dev + '/js/bootstrap4'));
+    // Copy all Bootstrap 4 JS files
+    streams.push(
+        gulp.src(basePaths.node + 'bootstrap/dist/js/**/*.js')
+            .pipe(gulp.dest(basePaths.dev + '/js/bootstrap4'));
+    );
   
-// Copy all Bootstrap SCSS files
-    gulp.src(basePaths.node + 'bootstrap/scss/**/*.scss')
-       .pipe(gulp.dest(basePaths.dev + '/sass/bootstrap4'));
+    // Copy all Bootstrap 4 SCSS files
+    streams.push(
+        gulp.src(basePaths.node + 'bootstrap/scss/**/*.scss')
+            .pipe(gulp.dest(basePaths.dev + '/sass/bootstrap4'))
+    );
 
-////////////////// End Bootstrap 4 Assets /////////////////////////
+    // Copy all Font Awesome Fonts
+    streams.push(
+        gulp.src(basePaths.node + 'font-awesome/fonts/**/*.{ttf,woff,woff2,eof,svg}')
+             .pipe(gulp.dest('./fonts/vendor'))
+        );
 
-// Copy all Font Awesome Fonts
-    gulp.src(basePaths.node + 'font-awesome/fonts/**/*.{ttf,woff,woff2,eof,svg}')
-        .pipe(gulp.dest('./fonts'));
+    // Copy all Font Awesome SCSS files
+    streams.push(
+        gulp.src(basePaths.node + 'font-awesome/scss/*.scss')
+             .pipe(gulp.dest(basePaths.dev + '/sass/fontawesome'))
+        );
 
-// Copy all Font Awesome SCSS files
-    gulp.src(basePaths.node + 'font-awesome/scss/*.scss')
-        .pipe(gulp.dest(basePaths.dev + '/sass/fontawesome'));
+    // Copy jQuery
+    streams.push(
+        gulp.src(basePaths.node + 'jquery/dist/*.js')
+             .pipe(gulp.dest(basePaths.js + '/vendor'))
+        );
 
-// Copy jQuery
-    gulp.src(basePaths.node + 'jquery/dist/*.js')
-        .pipe(gulp.dest(basePaths.js));
+    // _s SCSS files
+    streams.push(
+        gulp.src(basePaths.node + 'undescores-for-npm/sass/**/*.scss')
+             .pipe(gulp.dest(basePaths.dev + '/sass/underscores'))
+        );
 
-// _s SCSS files
-    gulp.src(basePaths.node + 'undescores-for-npm/sass/**/*.scss')
-        .pipe(gulp.dest(basePaths.dev + '/sass/underscores'));
+    // _s JS files into /src/js
+    streams.push(
+        gulp.src(basePaths.node + 'undescores-for-npm/js/*.js')
+             .pipe(gulp.dest(basePaths.dev + '/js'))
+        );
 
-// _s JS files into /src/js
-    gulp.src(basePaths.node + 'undescores-for-npm/js/*.js')
-        .pipe(gulp.dest(basePaths.dev + '/js'));
+    // _s JS files into /js
+    streams.push(
+        gulp.src(basePaths.node + 'undescores-for-npm/js/*.js')
+             .pipe(gulp.dest(basePaths.js + '/vendor'))
+        );
 
-// _s JS files into /js
-    gulp.src(basePaths.node + 'undescores-for-npm/js/*.js')
-        .pipe(gulp.dest(basePaths.js));
-
-// Copy Popper JS files
-    gulp.src(basePaths.node + 'popper.js/dist/umd/popper.min.js')
-        .pipe(gulp.dest(basePaths.js));
+    // Copy Popper JS files
+    streams.push(
+        gulp.src(basePaths.node + 'popper.js/dist/umd/popper.min.js')
+             .pipe(gulp.dest(basePaths.js + '/vendor'))
+        );
         
-    gulp.src(basePaths.node + 'popper.js/dist/umd/popper.js')
-        .pipe(gulp.dest(basePaths.js));
-    return stream;
+    streams.push(
+        gulp.src(basePaths.node + 'popper.js/dist/umd/popper.js')
+             .pipe(gulp.dest(basePaths.js + '/vendor'))
+        );
+    
+    return streams;
 });
 
 


### PR DESCRIPTION
We should return a merged event stream instead of one event stream to assure async support for `copy-assets`.