### PR TITLE
Font Awesome 5 (solid) Integration into Bootstrap WP Walker

### DIFF
--- a/inc/bootstrap-wp-navwalker.php
+++ b/inc/bootstrap-wp-navwalker.php
@@ -89,8 +89,8 @@ class understrap_WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 			// remove Font Awesome icon from classes array and save the icon
 			// we will add the icon back in via a <span> below so it aligns with
 			// the menu item
-			if ( in_array( 'fa', $classes ) ) {
-				$key         = array_search( 'fa', $classes );
+			if ( in_array( 'fas', $classes ) ) {
+				$key         = array_search( 'fas', $classes );
 				$icon        = $classes[ $key + 1 ];
 				$class_names = str_replace( $classes[ $key + 1 ], '', $class_names );
 				$class_names = str_replace( $classes[ $key ], '', $class_names );
@@ -123,9 +123,9 @@ class understrap_WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 				}
 			}
 			$item_output = $args->before;
-			// Font Awesome icons
+			// Font Awesome 5 Icons
 			if ( ! empty( $icon ) ) {
-				$item_output .= '<a' . $attributes . '><span class="fa ' . esc_attr( $icon ) . '"></span>&nbsp;';
+				$item_output .= '<a' . $attributes . '><span class="fas ' . esc_attr( $icon ) . '"></span>&nbsp;';
 			} else {
 				$item_output .= '<a' . $attributes . '>';
 			}


### PR DESCRIPTION
Hello this is my first time contributing to a project, hope I get it right. Working with this framework and wanted to update to Font Awesome 5. I was able to easily edit the header and comment out the Font Awesome 4 assets but the icons stopped showing up in the nav bar.

After some tinkering, I was able to find this quick little fix. It only supports the solid format ['fas'] at the moment, but maybe someone else (or myself if I get to it) can finish it off.