### PR TITLE
Adjusting theme colors via Customizer

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -184,12 +184,12 @@ if ( ! function_exists( 'understrap_theme_customize_css' ) ) {
 
 			if (!empty( get_theme_mod('primary_color') ) ) {
 				echo "a { color: " . get_theme_mod('primary_color') . "; }\r\n";
-				echo "*[class*='primary'] { background-color: " . get_theme_mod('primary_color') . "; border-color: " . get_theme_mod('primary_color') . "; }\r\n";
+				echo "*[class*='primary'] { background-color: " . get_theme_mod('primary_color') . " !important; border-color: " . get_theme_mod('primary_color') . " !important; }\r\n";
 			}
 
 			if (!empty( get_theme_mod('primary_hover_color') ) ) {
 				echo "a:hover { color: " . get_theme_mod('primary_hover_color') . "; }\r\n";
-				echo "*[class*='primary']:hover { background-color: " . get_theme_mod('primary_hover_color') . ";  border-color: " . get_theme_mod('primary_hover_color') . "; }\r\n";
+				echo "*[class*='primary']:hover { background-color: " . get_theme_mod('primary_hover_color') . " !important;  border-color: " . get_theme_mod('primary_hover_color') . " !important; }\r\n";
 			}
 
 		echo "</style>\r\n";

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -32,6 +32,54 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 	 */
 	function understrap_theme_customize_register( $wp_customize ) {
 
+		// Theme text colors
+		$wp_customize->add_setting( 'text_color', array(
+			'default'		=> '',
+			'type'			=> 'theme_mod',
+			'transport'		=> 'postMessage',
+			'capability'	=> 'edit_theme_options',
+		) );
+		
+		$wp_customize->add_control(
+			new WP_Customize_Color_Control( $wp_customize, 'text_color', array(
+				'label'   => __( 'Text Color', 'understrap' ),
+				'section' => 'colors',
+				'settings'   => 'text_color',
+				)
+			) );
+
+		$wp_customize->add_setting( 'primary_color', array(
+			'default'		=> '',
+			'type'			=> 'theme_mod',
+			'transport'		=> 'postMessage',
+			'capability'	=> 'edit_theme_options',
+		) );
+		
+		$wp_customize->add_control(
+			new WP_Customize_Color_Control( $wp_customize, 'primary_color', array(
+				'label'   => __( 'Primary Color', 'understrap' ),
+				'description'	=> 'Set up Bootstraps "Primary" color which affects links, buttons etc.',
+				'section' => 'colors',
+				'settings'   => 'primary_color',
+				)
+			) );
+
+		$wp_customize->add_setting( 'primary_hover_color', array(
+			'default'		=> '',
+			'type'			=> 'theme_mod',
+			'transport'		=> 'postMessage',
+			'capability'	=> 'edit_theme_options',
+		) );
+		
+		$wp_customize->add_control(
+			new WP_Customize_Color_Control( $wp_customize, 'primary_hover_color', array(
+				'label'   => __( 'Primary Hover Color', 'understrap' ),
+				'section' => 'colors',
+				'settings'   => 'primary_hover_color',
+				)
+			) );
+
+
 		// Theme layout settings.
 		$wp_customize->add_section( 'understrap_theme_layout_options', array(
 			'title'       => __( 'Theme Layout Settings', 'understrap' ),
@@ -122,3 +170,30 @@ if ( ! function_exists( 'understrap_customize_preview_js' ) ) {
 	}
 }
 add_action( 'customize_preview_init', 'understrap_customize_preview_js' );
+
+/**
+ * Read Customizer Settings and output them in embedded CSS.
+ */
+if ( ! function_exists( 'understrap_theme_customize_css' ) ) {
+	function understrap_theme_customize_css() {
+		echo "<style type=\"text/css\">\r\n";
+
+			if (!empty( get_theme_mod('text_color') ) ) {
+				echo "body { color: " . get_theme_mod('text_color') . "; }\r\n";
+			}
+
+			if (!empty( get_theme_mod('primary_color') ) ) {
+				echo "a { color: " . get_theme_mod('primary_color') . "; }\r\n";
+				echo "*[class*='primary'] { background-color: " . get_theme_mod('primary_color') . "; border-color: " . get_theme_mod('primary_color') . "; }\r\n";
+			}
+
+			if (!empty( get_theme_mod('primary_hover_color') ) ) {
+				echo "a:hover { color: " . get_theme_mod('primary_hover_color') . "; }\r\n";
+				echo "*[class*='primary']:hover { background-color: " . get_theme_mod('primary_hover_color') . ";  border-color: " . get_theme_mod('primary_hover_color') . "; }\r\n";
+			}
+
+		echo "</style>\r\n";
+	}
+}
+
+add_action( 'wp_head', 'understrap_theme_customize_css');

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -39,4 +39,37 @@
 			}
 		} );
 	} );
+
+	wp.customize( 'text_color', function( value ) {
+		value.bind( function( to ) {
+			$( 'body' ).css( {
+				'color': to
+			} );
+		} );
+	} );
+
+	wp.customize( 'primary_color', function( value ) {
+		value.bind( function( to ) {
+			$( 'a' ).css( {
+				'color': to
+			} );
+			$( '*[class*="primary"]' ).css( {
+				'background-color': to,
+				'border-color': to
+			} );
+		} );
+	} );
+
+	wp.customize( 'primary_hover_color', function( value ) {
+		value.bind( function( to ) {
+			$( 'a' ).css( {
+				'color': to
+			} );
+			$( '*[class*="primary"]:hover' ).css( {
+				'background-color': to,
+				'border-color': to
+			} );
+		} );
+	} );
+
 } )( jQuery );

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -60,7 +60,7 @@
 		} );
 	} );
 
-	wp.customize( 'primary_hover_color', function( value ) {
+	wp.customize( 'primary_hover_color', function( value ) { 
 		value.bind( function( to ) {
 			$( 'a' ).css( {
 				'color': to


### PR DESCRIPTION
Well, i thought it was not neccessary to only be able to adjust theme colors via SCSS and/or custom css. This pull request will make it possible to adjust them via the customizer. Needs enhancements though.

If anyone may jump in: Try to set up Primary hover colour. It will NOT get displayed on the live site, but only on the customizer live preview.
Any clues why?