### PR TITLE
Remove unnecessary wrapper classes from #wrapper-navbar

### DIFF
--- a/header.php
+++ b/header.php
@@ -28,7 +28,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 <div class="hfeed site" id="page">
 
 	<!-- ******************* The Navbar Area ******************* -->
-<div class="wrapper-fluid wrapper-navbar" id="wrapper-navbar" itemscope itemtype="http://schema.org/WebSite">
+	<div id="wrapper-navbar" itemscope itemtype="http://schema.org/WebSite">
 
 		<a class="skip-link screen-reader-text sr-only" href="#content"><?php esc_html_e( 'Skip to content', 'understrap' ); ?></a>
 
@@ -78,4 +78,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 		</nav><!-- .site-navigation -->
 
-	</div><!-- .wrapper-navbar end -->
+	</div><!-- #wrapper-navbar end -->


### PR DESCRIPTION
Responding to issue #334, removed unnecessary wrapper classes from #wrapper-navbar
