### PR TITLE
include minified css

### DIFF
--- a/inc/editor.php
+++ b/inc/editor.php
@@ -9,7 +9,7 @@
  * Registers an editor stylesheet for the theme.
  */
 function understrap_wpdocs_theme_add_editor_styles() {
-  add_editor_style( 'css/custom-editor-style.css' );
+  add_editor_style( 'css/custom-editor-style.min.css' );
 }
 add_action( 'admin_init', 'understrap_wpdocs_theme_add_editor_styles' );
 


### PR DESCRIPTION
The gulp fix for minify also minifies custom-editor-style.css.
Fixed to include the minified version b47d327