### PR TITLE
Left-sidebar-check improvement

### DIFF
--- a/global-templates/left-sidebar-check.php
+++ b/global-templates/left-sidebar-check.php
@@ -15,20 +15,22 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 	<?php get_sidebar( 'left' ); ?>
 <?php endif; ?>
 
-<?php 
+<?php
 	$html = '';
 	if ( 'right' === $sidebar_pos || 'left' === $sidebar_pos ) {
 		$html = '<div class="';
-		if ( is_active_sidebar( 'right-sidebar' ) || is_active_sidebar( 'left-sidebar' ) ) {
+		if ( ( is_active_sidebar( 'right-sidebar' ) && 'right' === $sidebar_pos ) || ( is_active_sidebar( 'left-sidebar' ) && 'left' === $sidebar_pos ) ) {
 			$html .= 'col-md-8 content-area" id="primary">';
 		} else {
 			$html .= 'col-md-12 content-area" id="primary">';
 		}
 		echo $html; // WPCS: XSS OK.
-	} elseif ( is_active_sidebar( 'right-sidebar' ) && is_active_sidebar( 'left-sidebar' ) ) {
+	} elseif ( 'both' === $sidebar_pos ) {
 		$html = '<div class="';
-		if ( 'both' === $sidebar_pos ) {
+		if ( is_active_sidebar( 'right-sidebar' ) && is_active_sidebar( 'left-sidebar' ) ) {
 			$html .= 'col-md-6 content-area" id="primary">';
+		} elseif ( is_active_sidebar( 'right-sidebar' ) || is_active_sidebar( 'left-sidebar' ) ) {
+			$html .= 'col-md-8 content-area" id="primary">';
 		} else {
 			$html .= 'col-md-12 content-area" id="primary">';
 		}
@@ -36,4 +38,3 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 	} else {
 	    echo '<div class="col-md-12 content-area" id="primary">';
 	}
-


### PR DESCRIPTION
Make php logic more fail-proof.

The code in the left-sidebar-check template requires the sidebar to be active, which means that if there aren't widgets in the corresponding sidebar it doesn't produce an ideal layout, and in the case of when both sidebars are set but one isn't active it doesn't produce the correct layout.

## Current left-sidebar-check behaviour:
- When set to "both" and when one of the two sidebars is empty: it gives "col-md-12". (should be col-md-8)
- When set to "left" with left sidebar empty and widgets in right sidebar: it gives "col-md-8" with no sidebar generated. (should be col-md-12)
- Same for when set to "right" with empty right sidebar.
- When set to "left" or "right" with both sidebars empty: it gives "col-md-12"

Please see these examples:
### Set "both" with left or right sidebar empty. (col-md-12)
![both-with-one-empty](https://user-images.githubusercontent.com/25933268/38047583-3af2b562-3280-11e8-9c9a-aba7b7a4d4ab.png)

### Set "left" with left sidebar empty, but widgets in right sidebar. (col-md-8)
![left-empty-with-right-full](https://user-images.githubusercontent.com/25933268/38048580-020ba5b2-3283-11e8-90f6-41b2c652317f.png)






Usually there would be content in the chosen sidebar, but in case someone does something dynamic I think the code should be a bit more flexible. This ensures that a good layout is presented regardless of configuration, while still allowing the theme to function as it was intended. There are cases where sidebar content, or even sidebar position is displayed dynamically. Just a bit extra code to help. This behaviour that an empty sidebar causes should also be documented in the Understrap docs.

This was brought up here https://github.com/understrap/understrap/issues/606#issuecomment-375742917 , but I think missed before it was closed, so I figured a PR would bring discussion and make it easier. Let me know if my thinking here is correct.