### PR TITLE
typeo in imagemin-watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,9 +107,8 @@ gulp.task( 'watch', function() {
  * Ensures the 'imagemin' task is complete before reloading browsers
  * @verbose
  */
-gulp.task( 'imagemin-watch', ['imagemin'], function( done ) {
+gulp.task( 'imagemin-watch', ['imagemin'], function( ) {
   browserSync.reload();
-  done();
 });
 
 // Run:


### PR DESCRIPTION
ohh gee, I made a mistake in the patch.

it's supposed to be

```

/**
 * Ensures the 'imagemin' task is complete before reloading browsers
 * @verbose
 */
gulp.task( 'imagemin-watch', ['imagemin'], function( ) {
  browserSync.reload();

});
```

Sorry for the inconvenience