### PR TITLE
Change type of package to wordpress-theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "name": "holger1411/understrap",
     "description": "Combines Automattic´s Underscores Starter Theme and Bootstrap 4",
-    "type": "library",
+    "type": "wordpress-theme",
     "license": "GPL-2.0",
     "minimum-stability": "stable",
-    "require": {},
+    "require": {"composer/installers": "^1.5"},
     "keywords": ["wordpress","theme","bootstrap"],
     "homepage": "https://github.com/holger1411/understrap"
 }


### PR DESCRIPTION
If you set the package up to use a type of "wordpress-theme" and require composer/installers you can let composer install the theme to the "wp-content/themes" folder. Can be useful in wordpress sites using composer.