### PR TITLE
Remove duplicate theme JS enqueue, update comment

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -7,7 +7,7 @@
 
 if ( ! function_exists( 'understrap_scripts' ) ) {
 	/**
-	 * Load theme's JavaScript sources.
+	 * Load theme's JavaScript and CSS sources.
 	 */
 	function understrap_scripts() {
 		// Get the theme data.
@@ -22,7 +22,6 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 		
 		$js_version = $theme_version . '.' . filemtime(get_template_directory() . '/js/theme.min.js');
 		wp_enqueue_script( 'understrap-scripts', get_template_directory_uri() . '/js/theme.min.js', array(), $js_version, true );
-		wp_enqueue_script( 'understrap-scripts', get_template_directory_uri() . '/js/theme.min.js', array(), $the_theme->get( 'Version' ), true );
 		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 			wp_enqueue_script( 'comment-reply' );
 		}


### PR DESCRIPTION
Howdy Holger,

I believe the `theme.min.js` file was enqueued twice; once using old method and again using new. This pull request removes the old enqueue method.

I also added _CSS_ to the comment as it's enqueuing more than JS.

I hope that helps!