### PR TITLE
ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist-product
 npm-debug.log
 
 /vendor/
+
+.DS_Store


### PR DESCRIPTION
Noticed that sometimes git complaints about .DS_Store files being untracked.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.DS_Store
	inc/.DS_Store
```

They should never be tracked.

From wikipedia:

> In the Apple macOS operating system, .DS_Store is a file that stores custom attributes of its containing folder, such as the position of icons or the choice of a background image. The name is an abbreviation of Desktop Services Store, reflecting its purpose.

So it's pretty much garbage.