### PR TITLE
Remove closing div from WooCommerce function

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -49,7 +49,6 @@ if ( ! function_exists( 'understrap_woocommerce_wrapper_start' ) ) {
 if ( ! function_exists( 'understrap_woocommerce_wrapper_end' ) ) {
 function understrap_woocommerce_wrapper_end() {
 	echo '</main><!-- #main -->';
-	echo '</div><!-- #primary -->';
 	get_template_part( 'global-templates/right-sidebar-check' );
   echo '</div><!-- .row -->';
 	echo '</div><!-- Container end -->';


### PR DESCRIPTION
#primary div has been moved to **right-sidebar-check.php**

This fixes sidebar layout in WooCommerce.

https://github.com/understrap/understrap/commit/548f4f04c1947da6e5238d8a17309e50e8bf8789