### PR TITLE
dynamic prev_next

### DIFF
--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -12,7 +12,7 @@ if ( ! function_exists ( 'understrap_pagination' ) ) {
 
 	    $args = wp_parse_args( $args, [
 	        'mid_size'           => 2,
-	        'prev_next'          => false,
+	        'prev_next'          => true,
 	        'prev_text'          => __('&laquo;', 'understrap'),
 	        'next_text'          => __('&raquo;', 'understrap'),
 	        'screen_reader_text' => __('Posts navigation', 'understrap'),
@@ -21,35 +21,21 @@ if ( ! function_exists ( 'understrap_pagination' ) ) {
 	    ]);
 
 	    $links     = paginate_links($args);
-	    $next_link = get_next_posts_page_link();
-	    $prev_link = get_previous_posts_page_link();
 
 	    ?>
 
 	    <nav aria-label="<?php echo $args['screen_reader_text']; ?>">
 	        <ul class="pagination">
-	            <li class="page-item">
-	                <a class="page-link" href="<?php echo esc_attr($prev_link); ?>" aria-label="<?php echo __('Previous', 'understrap'); ?>">
-	                    <span aria-hidden="true"><?php echo esc_attr($args['prev_text']); ?></span>
-	                    <span class="sr-only"><?php echo __('Previous', 'understrap'); ?></span>
-	                </a>
-	            </li>
-
+			
 	            <?php
-	            $i = 1;
+	                $i = 1;
 	                foreach ( $links as $link ) { ?>
 	                    <li class="page-item <?php if ($i == $args['current']) { echo 'active'; }; ?>">
-	            <?php echo str_replace( 'page-numbers', 'page-link', $link ); ?>
+	                        <?php echo str_replace( 'page-numbers', 'page-link', $link ); ?>
 	                    </li>
 
 	            <?php $i++;} ?>
 
-	            <li class="page-item">
-	                <a class="page-link" href="<?php echo esc_attr($next_link); ?>" aria-label="<?php echo __('Next', 'understrap'); ?>">
-	                    <span aria-hidden="true"><?php echo esc_attr($args['next_text']); ?></span>
-	                    <span class="sr-only"><?php echo __('Next', 'understrap'); ?></span>
-	                </a>
-	            </li>
 	        </ul>
 	    </nav>
 	    <?php

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -6,38 +6,47 @@
  */
 
 if ( ! function_exists ( 'understrap_pagination' ) ) {
-	function understrap_pagination($args = [], $class = 'pagination') {
 
-	    if ($GLOBALS['wp_query']->max_num_pages <= 1) return;
+    function understrap_pagination($args = [], $class = 'pagination') {
 
-	    $args = wp_parse_args( $args, [
-	        'mid_size'           => 2,
-	        'prev_next'          => true,
-	        'prev_text'          => __('&laquo;', 'understrap'),
-	        'next_text'          => __('&raquo;', 'understrap'),
-	        'screen_reader_text' => __('Posts navigation', 'understrap'),
-	        'type'               => 'array',
-	        'current'            => max( 1, get_query_var('paged') ),
-	    ]);
+        if ($GLOBALS['wp_query']->max_num_pages <= 1) return;
 
-	    $links     = paginate_links($args);
+        $args = wp_parse_args( $args, [
+            'mid_size'           => 2,
+            'prev_next'          => true,
+            'prev_text'          => __('&laquo;', 'understrap'),
+            'next_text'          => __('&raquo;', 'understrap'),
+            'screen_reader_text' => __('Posts navigation', 'understrap'),
+            'type'               => 'array',
+            'current'            => max( 1, get_query_var('paged') ),
+        ]);
 
-	    ?>
+        $links = paginate_links($args);
 
-	    <nav aria-label="<?php echo $args['screen_reader_text']; ?>">
-	        <ul class="pagination">
-			
-	            <?php
-	                $i = 1;
-	                foreach ( $links as $link ) { ?>
-	                    <li class="page-item <?php if ($i == $args['current']) { echo 'active'; }; ?>">
-	                        <?php echo str_replace( 'page-numbers', 'page-link', $link ); ?>
-	                    </li>
+        ?>
 
-	            <?php $i++;} ?>
+        <nav aria-label="<?php echo $args['screen_reader_text']; ?>">
 
-	        </ul>
-	    </nav>
-	    <?php
-	}
+            <ul class="pagination">
+
+                <?php
+
+                    foreach ( $links as $key => $link ) { ?>
+
+                        <li class="page-item <?php echo strpos( $link, 'current' ) ? 'active' : '' ?>">
+
+                            <?php echo str_replace( 'page-numbers', 'page-link', $link ); ?>
+
+                        </li>
+
+                <?php } ?>
+
+            </ul>
+
+        </nav>
+
+        <?php
+    }
 }
+
+?>


### PR DESCRIPTION
I've noticed that with the current implementation, next arrow is still shown if there are no more pages.
By setting prev_next to true, WordPress should handle the generation of next and previous arrows. 
This also means that the code is dramatically simplified.

But please test this, because I don't remember why I didn't write the code this way in the first place.
Maybe because there was some fringe case I tried to rectify?

I'm just referencing this issue #663 just because it made me look at `understrap_pagination` some more 