### PR TITLE
Added cookies checkbox support for inc/custom-comments.php

### DIFF
--- a/inc/custom-comments.php
+++ b/inc/custom-comments.php
@@ -24,15 +24,17 @@ if ( ! function_exists( 'understrap_bootstrap_comment_form_fields' ) ) {
 		$aria_req  = ( $req ? " aria-required='true'" : '' );
 		$html5     = current_theme_supports( 'html5', 'comment-form' ) ? 1 : 0;
 		$fields    = array(
-			'author' => '<div class="form-group comment-form-author"><label for="author">' . __( 'Name',
+			'author'  => '<div class="form-group comment-form-author"><label for="author">' . __( 'Name',
 					'understrap' ) . ( $req ? ' <span class="required">*</span>' : '' ) . '</label> ' .
 			            '<input class="form-control" id="author" name="author" type="text" value="' . esc_attr( $commenter['comment_author'] ) . '" size="30"' . $aria_req . '></div>',
-			'email'  => '<div class="form-group comment-form-email"><label for="email">' . __( 'Email',
+			'email'   => '<div class="form-group comment-form-email"><label for="email">' . __( 'Email',
 					'understrap' ) . ( $req ? ' <span class="required">*</span>' : '' ) . '</label> ' .
 			            '<input class="form-control" id="email" name="email" ' . ( $html5 ? 'type="email"' : 'type="text"' ) . ' value="' . esc_attr( $commenter['comment_author_email'] ) . '" size="30"' . $aria_req . '></div>',
-			'url'    => '<div class="form-group comment-form-url"><label for="url">' . __( 'Website',
+			'url'     => '<div class="form-group comment-form-url"><label for="url">' . __( 'Website',
 					'understrap' ) . '</label> ' .
 			            '<input class="form-control" id="url" name="url" ' . ( $html5 ? 'type="url"' : 'type="text"' ) . ' value="' . esc_attr( $commenter['comment_author_url'] ) . '" size="30"></div>',
+			'cookies' => '<div class="form-group form-check comment-form-cookies-consent"><input class="form-check-input" id="wp-comment-cookies-consent" name="wp-comment-cookies-consent" type="checkbox" value="yes"' . $consent . ' /> ' .
+			         '<label class="form-check-label" for="wp-comment-cookies-consent">' . __( 'Save my name, email, and website in this browser for the next time I comment.' ) . '</label></div>',
 		);
 
 		return $fields;


### PR DESCRIPTION
Since WordPress 4.9.6, there is a new checkbox in the comment form template needed:
https://wordpress.org/news/2018/05/wordpress-4-9-6-privacy-and-maintenance-release/

This pull request adds support for this field in inc/custom-comments.php

Maybe this field also needs to be added to the themes translation files.