### PR TITLE
Use template instead of stylesheet directory

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 	 */
 	function understrap_scripts() {
 
-		wp_enqueue_style( 'understrap-styles', get_stylesheet_directory_uri() . '/'. asset_path('css/theme.min.css'), array(), null);
+		wp_enqueue_style( 'understrap-styles', get_template_directory_uri() . '/'. asset_path('css/theme.min.css'), array(), null);
 
 		wp_enqueue_script( 'jquery');
 		wp_enqueue_script( 'popper-scripts', get_template_directory_uri() . '/js/popper.min.js', array(), false, true);


### PR DESCRIPTION
Hello !

I tried to use understrap as a parent theme for my latest wordpress work. I realize that a simple theme which is not using any builder to build a complete CSS stylesheet from the understrap one is broken.

Using the template directory instead of the stylesheet directory to include the theme stylesheet allows this simple child theme usage and doesn't break when only using understrap.

Let me know if this is ok for you.

Regards
Baudouin