### PR TITLE
revision strategy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,6 +102,7 @@ gulp.task( 'rev', function() {
     .pipe(rev())
     .pipe(gulp.dest('./'))  // write rev'd assets to build dir
     .pipe(rev.manifest())
+    .pipe(revDel({dest: './'}))
     .pipe(gulp.dest('./'));  // write manifest to build dir
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,6 +21,7 @@ var gulpSequence = require( 'gulp-sequence' );
 var replace = require( 'gulp-replace' );
 var autoprefixer = require( 'gulp-autoprefixer' );
 var rev = require('gulp-rev');
+var revDel = require('rev-del)';
 
 // Configuration file to keep your code DRY
 var cfg = require( './gulpconfig.json' );

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp-watch": "5.0.0",
     "merge2": "^1.2.1",
     "popper.js": "^1.12.9",
+    "rev-del": "^1.0.5",
     "run-sequence": "^2.2.1",
     "undescores-for-npm": "^1.0.0",
     "gulp-autoprefixer": "^5.0.0"


### PR DESCRIPTION
Add `rev-del` package to `package.json` and updated the revision task in `gulpfile.js`

US creates revision of `theme.min.css` and `theme.min.js` and stores references in `rev-manifest.json`.
rev-del will make sure that a max of two revisions + the current one is kepts.
This is to prevent excessive revisions in /csss and /js folder.

