### PR TITLE
Fix missing sidebar.php

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * The sidebar containing the main widget area.
+ *
+ * @package understrap
+ */
+
+if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+	return;
+}
+?>
+
+<div class="col-md-4 widget-area" id="secondary" role="complementary">
+
+	<?php dynamic_sidebar( 'sidebar-1' ); ?>
+
+</div><!-- #secondary -->


### PR DESCRIPTION
**PHP error**

> Theme without sidebar.php is deprecated since version 3.0.0 with no alternative available.

The `sidebar.php` file was dropped when sidebar templates were reorganized and moved to the directory `sidebar-templates.`

This fixes issue #733