### PR TITLE
Swap shorthand array `[]` to `array()` in pagination function definition

### DIFF
--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -7,7 +7,7 @@
 
 if ( ! function_exists ( 'understrap_pagination' ) ) {
 
-    function understrap_pagination($args = [], $class = 'pagination') {
+	function understrap_pagination( $args = array(), $class = 'pagination' ) {
 
         if ($GLOBALS['wp_query']->max_num_pages <= 1) return;
 

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -11,15 +11,15 @@ if ( ! function_exists ( 'understrap_pagination' ) ) {
 
         if ($GLOBALS['wp_query']->max_num_pages <= 1) return;
 
-        $args = wp_parse_args( $args, [
-            'mid_size'           => 2,
-            'prev_next'          => true,
-            'prev_text'          => __('&laquo;', 'understrap'),
-            'next_text'          => __('&raquo;', 'understrap'),
-            'screen_reader_text' => __('Posts navigation', 'understrap'),
-            'type'               => 'array',
-            'current'            => max( 1, get_query_var('paged') ),
-        ]);
+		$args = wp_parse_args( $args, array(
+			'mid_size'           => 2,
+			'prev_next'          => true,
+			'prev_text'          => __('&laquo;', 'understrap'),
+			'next_text'          => __('&raquo;', 'understrap'),
+			'screen_reader_text' => __('Posts navigation', 'understrap'),
+			'type'               => 'array',
+			'current'            => max( 1, get_query_var('paged') ),
+		) );
 
         $links = paginate_links($args);
 


### PR DESCRIPTION
This swaps shorthand array definition to longhand to retain php<5.6 compatibility.

Fixes: #742 