### PR TITLE
Update Woocommerce form-coupon template to 3.4.4

### DIFF
--- a/woocommerce/checkout/form-coupon.php
+++ b/woocommerce/checkout/form-coupon.php
@@ -12,12 +12,12 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.4.4
  */
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! wc_coupons_enabled() || ! empty( WC()->cart->applied_coupons ) ) { // @codingStandardsIgnoreLine.
+if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 	return;
 }
 


### PR DESCRIPTION
* Woocommerce template `checkout/form-coupon.php` is at version 3.4.0
* When Woocommerce is updated to 3.4.4 the Woocommerce status check shows `checkout/form-coupon.php` is outdated and needs to be updated to 3.4.4
* `form-coupon.php` from the Woocommerce 3.4.4 plugin replaces UnderStrap version 3.4.0 and is updated for Bootstrap 4 markup and the `understrap` text domain.