### PR TITLE
Added site info hook 

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -7,7 +7,6 @@
  * @package understrap
  */
 
-$the_theme = wp_get_theme();
 $container = get_theme_mod( 'understrap_container_type' );
 ?>
 
@@ -25,18 +24,8 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 					<div class="site-info">
 
-							<a href="<?php  echo esc_url( __( 'http://wordpress.org/','understrap' ) ); ?>"><?php printf( 
-							/* translators:*/
-							esc_html__( 'Proudly powered by %s', 'understrap' ),'WordPress' ); ?></a>
-								<span class="sep"> | </span>
-					
-							<?php printf( // WPCS: XSS ok.
-							/* translators:*/
-								esc_html__( 'Theme: %1$s by %2$s.', 'understrap' ), $the_theme->get( 'Name' ),  '<a href="'.esc_url( __('http://understrap.com', 'understrap')).'">understrap.com</a>' ); ?> 
-				
-							(<?php printf( // WPCS: XSS ok.
-							/* translators:*/
-								esc_html__( 'Version: %1$s', 'understrap' ), $the_theme->get( 'Version' ) ); ?>)
+						<?php understrap_site_info(); ?>
+
 					</div><!-- .site-info -->
 
 				</footer><!-- #colophon -->

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Custom hooks.
+ *
+ * @package understrap
+ */
+
+
+
+if ( ! function_exists( 'understrap_add_site_info' ) ) {
+  /**
+   * Add site info hook to WP hook library.
+   */
+  function understrap_site_info() {
+    do_action( 'understrap_site_info' );
+  }
+}
+
+if ( ! function_exists( 'understrap_add_site_info' ) ) {
+  add_action( 'understrap_site_info', 'understrap_add_site_info' );
+
+  /**
+   * Add site info content.
+   */
+  function understrap_add_site_info() {
+    $the_theme = wp_get_theme();
+    
+    $site_info = sprintf(
+      '<a href="%1$s">%2$s</a><span class="sep"> | </span>%3$s(%4$s)',
+      esc_url( __( 'http://wordpress.org/', 'understrap' ) ),
+      sprintf(
+        /* translators:*/
+        esc_html__( 'Proudly powered by %s', 'understrap' ), 'WordPress'
+      ),
+      sprintf( // WPCS: XSS ok.
+        /* translators:*/
+        esc_html__( 'Theme: %1$s by %2$s.', 'understrap' ), $the_theme->get( 'Name' ), '<a href="' . esc_url( __( 'http://understrap.com', 'understrap' ) ) . '">understrap.com</a>'
+      ),
+      sprintf( // WPCS: XSS ok.
+        /* translators:*/
+        esc_html__( 'Version: %1$s', 'understrap' ), $the_theme->get( 'Version' )
+      )
+    );
+
+    echo apply_filters( understrap_site_info_content, $site_info ); // WPCS: XSS ok.
+  }
+}

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -5,8 +5,6 @@
  * @package understrap
  */
 
-
-
 if ( ! function_exists( 'understrap_add_site_info' ) ) {
   /**
    * Add site info hook to WP hook library.


### PR DESCRIPTION
* added inc/hooks.php containing a hook with the default site info content
* replaced default site info content in footer.php with hook

A child theme no longer needs to rewrite the footer.php but can use a filter like so
```php
add_filter( 'understrap_site_info_content', 'child_theme_site_info' );
function child_theme_site_info() {
	// Here goes the new site info. E.g.
	?>
	Site info of child theme
	<?php
}
```
