### PR TITLE
Strapify select for WP default widgets

### DIFF
--- a/sass/understrap/understrap.scss
+++ b/sass/understrap/understrap.scss
@@ -40,6 +40,13 @@
 
 .aligncenter { margin: 0px auto; }
 
+.widget_categories,
+.widget_archive {
+	select { 
+		@extend .form-control;
+	}
+}
+
 // Post design
 .entry-footer span { padding-right: 10px; }
 


### PR DESCRIPTION
Eventually, simply using 
```scss
select { 
	@extend .form-control;
}
```
to capture all  `select` would be an option too.