### PR TITLE
Remove unnecessary call to count()

### DIFF
--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -22,7 +22,7 @@ if ( ! function_exists( 'understrap_slbd_count_widgets' ) ) {
 
 		if ( isset( $sidebars_widgets_count[ $sidebar_id ] ) ) :
 			$widget_count = count( $sidebars_widgets_count[ $sidebar_id ] );
-			$widget_classes = 'widget-count-' . count( $sidebars_widgets_count[ $sidebar_id ] );
+			$widget_classes = 'widget-count-' . $widget_count;
 			if ( $widget_count % 4 == 0 || $widget_count > 6 ) :
 				// Four widgets per row if there are exactly four or more than six
 				$widget_classes .= ' col-md-3';


### PR DESCRIPTION
`count( $sidebars_widgets_count[ $sidebar_id ] )` called twice though returned value from first call stored in `$widget_count`