### PR TITLE
Adhere to WP coding standards

### DIFF
--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -14,33 +14,34 @@ if ( ! function_exists( 'understrap_slbd_count_widgets' ) ) {
 		// If loading from front page, consult $_wp_sidebars_widgets rather than options
 		// to see if wp_convert_widget_settings() has made manipulations in memory.
 		global $_wp_sidebars_widgets;
-		if ( empty( $_wp_sidebars_widgets ) ) :
-			$_wp_sidebars_widgets = get_option( 'sidebars_widgets', array() );
-		endif;
+		$understrap_sidebars_widgets = $_wp_sidebars_widgets;
+		if ( empty( $understrap_sidebars_widgets ) ) {
+			$understrap_sidebars_widgets = get_option( 'sidebars_widgets', array() );
+		}
 
-		$sidebars_widgets_count = $_wp_sidebars_widgets;
+		$sidebars_widgets_count = $understrap_sidebars_widgets;
 
-		if ( isset( $sidebars_widgets_count[ $sidebar_id ] ) ) :
+		if ( isset( $sidebars_widgets_count[ $sidebar_id ] ) ) {
 			$widget_count = count( $sidebars_widgets_count[ $sidebar_id ] );
 			$widget_classes = 'widget-count-' . count( $sidebars_widgets_count[ $sidebar_id ] );
-			if ( $widget_count % 4 == 0 || $widget_count > 6 ) :
-				// Four widgets per row if there are exactly four or more than six
+			if ( 0 === $widget_count % 4 || $widget_count > 6 ) {
+				// Four widgets per row if there are exactly four or more than six.
 				$widget_classes .= ' col-md-3';
-			elseif ( 6 == $widget_count ) :
-				// If two widgets are published
+			} elseif ( 6 === $widget_count ) {
+				// If two widgets are published.
 				$widget_classes .= ' col-md-2';
-			elseif ( $widget_count >= 3 ) :
-				// Three widgets per row if there's three or more widgets 
+			} elseif ( $widget_count >= 3 ) {
+				// Three widgets per row if there's three or more widgets.
 				$widget_classes .= ' col-md-4';
-			elseif ( 2 == $widget_count ) :
-				// If two widgets are published
+			} elseif ( 2 === $widget_count ) {
+				// If two widgets are published.
 				$widget_classes .= ' col-md-6';
-			elseif ( 1 == $widget_count ) :
-				// If just on widget is active
+			} elseif ( 1 === $widget_count ) {
+				// If just on widget is active.
 				$widget_classes .= ' col-md-12';
-			endif; 
+			} 
 			return $widget_classes;
-		endif;
+		}
 	}
 }
 


### PR DESCRIPTION
See
* https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#brace-style
* https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#yoda-conditions
* https://codex.wordpress.org/Global_Variables

Plus: `$widget_count` is int, so use strict comparison