### PR TITLE
Define .screen-reader-text

### DIFF
--- a/sass/understrap/understrap.scss
+++ b/sass/understrap/understrap.scss
@@ -24,7 +24,7 @@
 
 .wp-caption-text { font-size: inherit; }
 
-.screen-reader-text { font-size: inherit; }
+.screen-reader-text { @extend .sr-only; }
 
 .alignleft {
   display: inline;


### PR DESCRIPTION
WP uses the class `.screen-reader-text` in some core stuff like widgets and therefore it should be properly defined. Also UnderStrap itself uses `.screen-reader-text` instead of `.sr-only` sometimes.