### PR TITLE
Focusable 'Skip to content'

### DIFF
--- a/header.php
+++ b/header.php
@@ -29,7 +29,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 	<!-- ******************* The Navbar Area ******************* -->
 	<div id="wrapper-navbar" itemscope itemtype="http://schema.org/WebSite">
 
-		<a class="skip-link screen-reader-text sr-only" href="#content"><?php esc_html_e( 'Skip to content', 'understrap' ); ?></a>
+		<a class="skip-link sr-only sr-only-focusable" href="#content"><?php esc_html_e( 'Skip to content', 'understrap' ); ?></a>
 
 		<nav class="navbar navbar-expand-md navbar-dark bg-primary">
 


### PR DESCRIPTION
* make 'Skip to content' focusable for sighted keyboard users
* `.sr-only` makes `.screen-reader-text` obsolete