### PR TITLE
Fixed typo in wp_enqueue_style() call in inc/wpcom.php

### DIFF
--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -32,7 +32,7 @@ if ( ! function_exists ( 'understrap_wpcom_setup' ) ) {
 				'url'    => '',
 			);
 		}
-		
+
 		/* Add WP.com print styles */
 		add_theme_support( 'print-styles' );
 	}
@@ -46,6 +46,6 @@ add_action( 'wp_enqueue_scripts', 'understrap_wpcom_styles' );
 
 if ( ! function_exists ( 'understrap_wpcom_styles' ) ) {
 	function understrap_wpcom_styles() {
-		wp_enqueue_style( 'understrap-wpcom', get_template_directory_uri() . '/inc/style-wpcom.css', '20160411' );
+		wp_enqueue_style( 'understrap-wpcom', get_template_directory_uri() . '/inc/style-wpcom.css', array(), '20160411' );
 	}
 }


### PR DESCRIPTION
Fixed a typo in wp_enqueue_style() call in inc/wpcom.php: file version passed as the $deps argument instead of $ver.