### PR TITLE
Move woocommerce product gallery slider width fix 

### DIFF
--- a/sass/understrap/understrap.scss
+++ b/sass/understrap/understrap.scss
@@ -43,11 +43,6 @@
 // Post design
 .entry-footer span { padding-right: 10px; }
 
-//Woocommerce product gallery slider width fix
-figure.woocommerce-product-gallery__wrapper { 
-  max-width: inherit !important; 
-}
-
 // Limit featured image size to 100%
 img.wp-post-image,
 article img,

--- a/sass/understrap/woocommerce.scss
+++ b/sass/understrap/woocommerce.scss
@@ -2,3 +2,8 @@
 .woocommerce-input-wrapper {
 	width: 100%;
 }
+
+// Woocommerce product gallery slider width fix
+figure.woocommerce-product-gallery__wrapper { 
+  max-width: inherit !important; 
+}


### PR DESCRIPTION
Move 'Woocommerce product gallery slider width fix' from understrap.scss to woocommerce.scss