### PR TITLE
Remove default class hfeed

### DIFF
--- a/header.php
+++ b/header.php
@@ -28,7 +28,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 <body <?php body_class(); ?>>
 
-<div class="hfeed site" id="page">
+<div class="site" id="page">
 
 	<!-- ******************* The Navbar Area ******************* -->
 	<div id="wrapper-navbar" itemscope itemtype="http://schema.org/WebSite">


### PR DESCRIPTION
The class `hfeed` is correctly added to non-singular pages only via the `understrap_body_classes` filter and should not be present on each page regardless of whether it is a feed or not.