### PR TITLE
Prevent modifications to read_more affecting dashboard expected behavior

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -110,7 +110,10 @@ if ( ! function_exists( 'understrap_custom_excerpt_more' ) ) {
 	 * @return string
 	 */
 	function understrap_custom_excerpt_more( $more ) {
-		return '';
+		if ( ! is_admin() ) {
+			$more = '';
+		}
+		return $more;
 	}
 }
 
@@ -125,8 +128,10 @@ if ( ! function_exists( 'understrap_all_excerpts_get_more_link' ) ) {
 	 * @return string
 	 */
 	function understrap_all_excerpts_get_more_link( $post_excerpt ) {
-
-		return $post_excerpt . ' [...]<p><a class="btn btn-secondary understrap-read-more-link" href="' . esc_url( get_permalink( get_the_ID() )) . '">' . __( 'Read More...',
-		'understrap' ) . '</a></p>';
+		if ( ! is_admin() ) {
+			$post_excerpt = $post_excerpt . ' [...]<p><a class="btn btn-secondary understrap-read-more-link" href="' . esc_url( get_permalink( get_the_ID() ) ) . '">' . __( 'Read More...',
+			'understrap' ) . '</a></p>';
+		}
+		return $post_excerpt;
 	}
 }


### PR DESCRIPTION
Makes sure modifications to the excerpt_more text only affect frontend and do not leak into the dashboard.

Fixes #825 