### PR TITLE
Tidy up left sidebar check

### DIFF
--- a/global-templates/left-sidebar-check.php
+++ b/global-templates/left-sidebar-check.php
@@ -15,29 +15,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 ?>
 
 <?php if ( 'left' === $sidebar_pos || 'both' === $sidebar_pos ) : ?>
-	<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
+    <?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
 <?php endif; ?>
 
-<?php
-	$html = '';
-	if ( 'right' === $sidebar_pos || 'left' === $sidebar_pos ) {
-		$html = '<div class="';
-		if ( ( is_active_sidebar( 'right-sidebar' ) && 'right' === $sidebar_pos ) || ( is_active_sidebar( 'left-sidebar' ) && 'left' === $sidebar_pos ) ) {
-			$html .= 'col-md-8 content-area" id="primary">';
-		} else {
-			$html .= 'col-md-12 content-area" id="primary">';
-		}
-		echo $html; // WPCS: XSS OK.
-	} elseif ( 'both' === $sidebar_pos ) {
-		$html = '<div class="';
-		if ( is_active_sidebar( 'right-sidebar' ) && is_active_sidebar( 'left-sidebar' ) ) {
-			$html .= 'col-md-6 content-area" id="primary">';
-		} elseif ( is_active_sidebar( 'right-sidebar' ) || is_active_sidebar( 'left-sidebar' ) ) {
-			$html .= 'col-md-8 content-area" id="primary">';
-		} else {
-			$html .= 'col-md-12 content-area" id="primary">';
-		}
-		echo $html; // WPCS: XSS OK.
-	} else {
-	    echo '<div class="col-md-12 content-area" id="primary">';
-	}
+<div class="col-md content-area" id="primary">


### PR DESCRIPTION
Removed all the unnecessary code to explicitly set the primary column's width. This is handled by Bootstrap 4's auto-layout. If we just provide it a column and its breakpoint, then as long as the sidebars have an explicit column width, the main will auto-fill. Fixes #827 