### PR TITLE
Fix inconsistent font weight

### DIFF
--- a/sass/understrap/understrap.scss
+++ b/sass/understrap/understrap.scss
@@ -121,3 +121,5 @@ a.skip-link {
       color: $navbar-dark-active-color;
     }
 }
+
+.navbar h1 { font-weight: $font-weight-normal; }


### PR DESCRIPTION
If the front page is the main blog page the site title is wrapped in an h1 tag with font weight equal to 500. On every other page the site title is wrapped in an a tag with font weight equal to 400.