### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -27,7 +27,7 @@ $understrap_includes = array(
 );
 
 foreach ( $understrap_includes as $file ) {
-	$filepath = locate_template( '/inc' . $file );
+	$filepath = locate_template( 'inc' . $file );
 	if ( ! $filepath ) {
 		trigger_error( sprintf( 'Error locating /inc%s for inclusion', $file ), E_USER_ERROR );
 	}


### PR DESCRIPTION
locate_template() adds a slash, resulting in a double slash if a slash is prepended to inc . $file - cee https://developer.wordpress.org/reference/functions/locate_template/