### PR TITLE
Fix dropdown when setting depth=0 in wp_nav_menu

### DIFF
--- a/inc/class-wp-bootstrap-navwalker.php
+++ b/inc/class-wp-bootstrap-navwalker.php
@@ -185,7 +185,7 @@ if ( ! class_exists( 'Understrap_WP_Bootstrap_Navwalker' ) ) {
 			$atts['target'] = ! empty( $item->target ) ? $item->target : '';
 			$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
 			// If item has_children add atts to <a>.
-			if ( isset( $args->has_children ) && $args->has_children && 0 === $depth && $args->depth > 1 ) {
+			if ( isset( $args->has_children ) && $args->has_children && 0 === $depth && $args->depth !== 1 ) {
 				$atts['href']          = '#';
 				$atts['data-toggle']   = 'dropdown';
 				$atts['aria-haspopup'] = 'true';


### PR DESCRIPTION
depth=0 is the default and should display the entire hierarchy according to WP docs. Without this change, you'd have to explicitly set depth to 2 or above in order for submenus to be displayed. With this change, depth=0 also works as expected.