### PR TITLE
Woocommerce Form Lost Password 3.5.2 update

### DIFF
--- a/woocommerce/myaccount/form-lost-password.php
+++ b/woocommerce/myaccount/form-lost-password.php
@@ -12,12 +12,13 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.5.2
  */
 
 defined( 'ABSPATH' ) || exit;
 
-wc_print_notices(); ?>
+do_action( 'woocommerce_before_lost_password_form' );
+?>
 
 <form method="post" class="woocommerce-ResetPassword lost_reset_password">
 
@@ -40,3 +41,5 @@ wc_print_notices(); ?>
 	<?php wp_nonce_field( 'lost_password', 'woocommerce-lost-password-nonce' ); ?>
 
 </form>
+<?php
+do_action( 'woocommerce_after_lost_password_form' );


### PR DESCRIPTION
Added do_action( 'woocommerce_before_lost_password_form' ); and do_action( 'woocommerce_after_lost_password_form' ); 

Removed wc_print_notices();