### PR TITLE
Update template to 3.5.3

### DIFF
--- a/woocommerce/checkout/payment.php
+++ b/woocommerce/checkout/payment.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.5.3
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -37,7 +37,10 @@ if ( ! is_ajax() ) {
 	<?php endif; ?>
 	<div class="form-row place-order">
 		<noscript>
-			<?php esc_html_e( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the <em>Update Totals</em> button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'understrap' ); ?>
+			<?php
+			/* translators: $1 and $2 opening and closing emphasis tags respectively */
+			printf( esc_html__( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the %1$sUpdate Totals%2$s button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'understrap' ), '<em>', '</em>' );
+			?>
 			<br/><button type="submit" class="btn btn-primary" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'understrap' ); ?>"><?php esc_html_e( 'Update totals', 'understrap' ); ?></button>
 		</noscript>
 


### PR DESCRIPTION
Update Woocommerce template 'checkout/payment.php' from 3.4.0 to 3.5.3
Add Bootrap button classes.
Change text domain from 'woocommerce' to 'understrap'.