### PR TITLE
Child Theme Support for `/css/theme.min.css`

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 		$theme_version = $the_theme->get( 'Version' );
 
 		$css_version = $theme_version . '.' . filemtime( get_template_directory() . '/css/theme.min.css' );
-		wp_enqueue_style( 'understrap-styles', get_stylesheet_directory_uri() . '/css/theme.min.css', array(), $css_version );
+		wp_enqueue_style( 'understrap-styles', get_template_directory_uri() . '/css/theme.min.css', array(), $css_version );
 
 		wp_enqueue_script( 'jquery' );
 


### PR DESCRIPTION
When this theme is used as a parent theme, the link to `theme.min.css` references a uri in the child theme. 
Unless one is created, it will result it broken styles.

.... side note: maybe if you want the file to be overridden via the child theme we could use `get_theme_file_uri()` instead?:

```php
wp_enqueue_style( 'understrap-styles', get_theme_file_uri('/css/theme.min.css'), array(), $css_version );
```
