### PR TITLE
Fix for #900

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -24,6 +24,7 @@ $understrap_includes = array(
 	'/class-wp-bootstrap-navwalker.php',    // Load custom WordPress nav walker.
 	'/woocommerce.php',                     // Load WooCommerce functions.
 	'/editor.php',                          // Load Editor functions.
+	'/deprecated.php',                      // Load deprecated functions.
 );
 
 foreach ( $understrap_includes as $file ) {

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Rest in peace.
+ *
+ * @package understrap
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Count number of widgets in a sidebar
+ * Used to add classes to widget areas so widgets can be displayed one, two, three or four per row
+ *
+ * @deprecated 0.8.9
+ */
+if ( ! function_exists( 'understrap_slbd_count_widgets' ) ) {
+	function understrap_slbd_count_widgets( $sidebar_id ) {
+		// If loading from front page, consult $_wp_sidebars_widgets rather than options
+		// to see if wp_convert_widget_settings() has made manipulations in memory.
+		global $_wp_sidebars_widgets;
+		if ( empty( $_wp_sidebars_widgets ) ) :
+			$_wp_sidebars_widgets = get_option( 'sidebars_widgets', array() );
+		endif;
+		$sidebars_widgets_count = $_wp_sidebars_widgets;
+		if ( isset( $sidebars_widgets_count[ $sidebar_id ] ) ) :
+			$widget_count = count( $sidebars_widgets_count[ $sidebar_id ] );
+			$widget_classes = 'widget-count-' . count( $sidebars_widgets_count[ $sidebar_id ] );
+			if ( $widget_count % 4 == 0 || $widget_count > 6 ) :
+				// Four widgets per row if there are exactly four or more than six
+				$widget_classes .= ' col-md-3';
+			elseif ( 6 == $widget_count ) :
+				// If two widgets are published
+				$widget_classes .= ' col-md-2';
+			elseif ( $widget_count >= 3 ) :
+				// Three widgets per row if there's three or more widgets 
+				$widget_classes .= ' col-md-4';
+			elseif ( 2 == $widget_count ) :
+				// If two widgets are published
+				$widget_classes .= ' col-md-6';
+			elseif ( 1 == $widget_count ) :
+				// If just on widget is active
+				$widget_classes .= ' col-md-12';
+			endif; 
+			return $widget_classes;
+		endif;
+	}
+}


### PR DESCRIPTION
Re-introduction of `understrap_slbd_count_widgets()` as deprecated function for those who used it in child themes.

#900 