### PR TITLE
Update form-reset-password template for Woocommerce 3.5.5

### DIFF
--- a/woocommerce/myaccount/form-reset-password.php
+++ b/woocommerce/myaccount/form-reset-password.php
@@ -12,11 +12,12 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.1
+ * @version 3.5.5
  */
 
 defined( 'ABSPATH' ) || exit;
 
+do_action( 'woocommerce_before_reset_password_form' );
 ?>
 
 <form method="post" class="woocommerce-ResetPassword lost_reset_password">
@@ -47,3 +48,6 @@ defined( 'ABSPATH' ) || exit;
 	<?php wp_nonce_field( 'reset_password', 'woocommerce-reset-password-nonce' ); ?>
 
 </form>
+<?php
+do_action( 'woocommerce_after_reset_password_form' );
+


### PR DESCRIPTION
* Use Woocommerce 3.5.5 template
* Replace text domain with 'understrap'
* Add Bootstrap classes for submit button