### PR TITLE
Add support for wp_body_open

### DIFF
--- a/header.php
+++ b/header.php
@@ -23,7 +23,13 @@ $container = get_theme_mod( 'understrap_container_type' );
 </head>
 
 <body <?php body_class(); ?>>
-
+<?php 
+if ( function_exists( 'wp_body_open' ) ) {
+    wp_body_open();
+} else {
+    do_action( 'wp_body_open' );
+}
+?>
 <div class="site" id="page">
 
 	<!-- ******************* The Navbar Area ******************* -->


### PR DESCRIPTION
5.2 will introduce a new `wp_body_open()` function that is used to trigger a `wp_body_open` action. This action is intended to allow developers to inject code immediately following the opening `<body>` tag. Themes are encouraged to begin using this hook as soon as 5.2 is released.

See https://make.wordpress.org/core/2019/04/24/miscellaneous-developer-updates-in-5-2/