### PR TITLE
Fix theme support for WooCommerce

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'understrap_woocommerce_support' ) ) {
 	 * Declares WooCommerce theme support.
 	 */
 	function understrap_woocommerce_support() {
-		add_theme_support( 'understrap' );
+		add_theme_support( 'woocommerce' );
 
 		// Add New Woocommerce 3.0.0 Product Gallery support.
 		add_theme_support( 'wc-product-gallery-lightbox' );


### PR DESCRIPTION
Looks like the add_theme_support() call should be 'woocommerce' and not 'understrap'.