### PR TITLE
Update ruleset

### DIFF
--- a/404.php
+++ b/404.php
@@ -86,4 +86,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #error-404-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/archive.php
+++ b/archive.php
@@ -70,4 +70,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 	</div><!-- #archive-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/author.php
+++ b/author.php
@@ -105,4 +105,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #author-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/author.php
+++ b/author.php
@@ -52,7 +52,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 							<?php if ( ! empty( $curauth->user_description ) ) : ?>
 								<dt><?php esc_html_e( 'Profile', 'understrap' ); ?></dt>
-								<dd><?php esc_html_e( $curauth->user_description ); ?></dd>
+								<dd><?php esc_html_e( $curauth->user_description, 'understrap' ); ?></dd>
 							<?php endif; ?>
 						</dl>
 					<?php endif; ?>

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,11 @@
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-		"wp-coding-standards/wpcs": "^2.1"
+		"wp-coding-standards/wpcs": "^2.1",
+		"phpcompatibility/php-compatibility": "^9.2"
 	},
 	"scripts": {
-		"test": ["phpcs"],
-		"fix": ["phpcbf"]
+		"test": ["vendor/bin/phpcs"],
+		"fix": ["vendor/bin/phpcbf"]
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f047956cbb4861fde466b775966f717",
+    "content-hash": "6e38e340aaa610ed48211f151263555e",
     "packages": [
         {
             "name": "composer/installers",
@@ -195,6 +195,64 @@
             "time": "2018-10-26T13:21:45+00:00"
         },
         {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-06-27T19:58:56+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.4.2",
             "source": {
@@ -250,12 +308,12 @@
             "version": "2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "bd9c33152115e6741e3510ff7189605b35167908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
                 "reference": "bd9c33152115e6741e3510ff7189605b35167908",
                 "shasum": ""
             },

--- a/global-templates/hero.php
+++ b/global-templates/hero.php
@@ -21,4 +21,4 @@ defined( 'ABSPATH' ) || exit;
 
 	</div>
 
-<?php endif; ?>
+<?php endif;

--- a/global-templates/right-sidebar-check.php
+++ b/global-templates/right-sidebar-check.php
@@ -17,4 +17,4 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php get_template_part( 'sidebar-templates/sidebar', 'right' ); ?>
 
-<?php endif; ?>
+<?php endif;

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -8,13 +8,14 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-/**
- * Count number of widgets in a sidebar
- * Used to add classes to widget areas so widgets can be displayed one, two, three or four per row
- *
- * @deprecated 0.8.9
- */
 if ( ! function_exists( 'understrap_slbd_count_widgets' ) ) {
+	/**
+	 * Count number of widgets in a sidebar
+	 * Used to add classes to widget areas so widgets can be displayed one, two, three or four per row
+	 *
+	 * @param int $sidebar_id The ID of the sidebar.
+	 * @deprecated 0.8.9
+	 */
 	function understrap_slbd_count_widgets( $sidebar_id ) {
 		// If loading from front page, consult $_wp_sidebars_widgets rather than options
 		// to see if wp_convert_widget_settings() has made manipulations in memory.

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -83,7 +83,7 @@ if ( ! function_exists( 'understrap_change_logo_class' ) ) {
  * Display navigation to next/previous post when applicable.
  */
 
-if ( ! function_exists ( 'understrap_post_nav' ) ) {
+if ( ! function_exists( 'understrap_post_nav' ) ) {
 	function understrap_post_nav() {
 		// Don't print empty markup if there's nowhere to navigate.
 		$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -55,4 +55,4 @@ if ( ! function_exists( 'understrap_pagination' ) ) {
 	}
 }
 
-?>
+

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -15,7 +15,7 @@ if ( ! isset( $content_width ) ) {
 
 add_action( 'after_setup_theme', 'understrap_setup' );
 
-if ( ! function_exists ( 'understrap_setup' ) ) {
+if ( ! function_exists( 'understrap_setup' ) ) {
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.
 	 *
@@ -90,7 +90,7 @@ if ( ! function_exists ( 'understrap_setup' ) ) {
 
 		// Set up the WordPress Theme logo feature.
 		add_theme_support( 'custom-logo' );
-		
+
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 

--- a/index.php
+++ b/index.php
@@ -72,4 +72,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #index-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/page-templates/both-sidebarspage.php
+++ b/page-templates/both-sidebarspage.php
@@ -57,4 +57,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/page-templates/fullwidthpage.php
+++ b/page-templates/fullwidthpage.php
@@ -52,4 +52,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #full-width-page-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/page-templates/left-sidebarpage.php
+++ b/page-templates/left-sidebarpage.php
@@ -51,4 +51,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/page-templates/right-sidebarpage.php
+++ b/page-templates/right-sidebarpage.php
@@ -51,4 +51,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/page.php
+++ b/page.php
@@ -54,4 +54,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -74,7 +74,7 @@
 	</rule>
 
 	<!-- A closing tag is not permitted at the end of a PHP file -->
-	<!-- <rule ref="Zend.Files.ClosingTag"/> -->
+	<rule ref="Zend.Files.ClosingTag"/>
 
 	<!-- Use the PHPCompatibility Ruleset -->
 	<config name="testVersion" value="5.2-99.0"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Theme Coding Standards">
-	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+<ruleset name="UnderStrap Coding Standards">
 
 	<!-- Set a description for this ruleset. -->
-	<description>A custom set of code standard rules to check for WordPress themes.</description>
+	<description>A custom set of code standard rules for UnderStrap.</description>
+
+	<!-- Show colors in console -->
+	<arg value="-colors"/>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<!-- Don't show warnings -->
+	<arg value="n"/>
 
 	<!-- Only check the PHP files -->
 	<arg name="extensions" value="php"/>
@@ -13,31 +20,86 @@
 	<file>.</file>
 
 	<!-- Ignore the vendor directory -->
-	<exclude-pattern>./vendor</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
 
-	<!-- Show colors in console -->
-	<arg value="-colors"/>
+	<!-- Use the WordPress Ruleset -->
+	<rule ref="WordPress">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd"/>
+		<exclude name="WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed"/>
+		<exclude name="WordPress.Security.EscapeOutput.UnsafePrintingFunction"/>
+		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
+		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
+		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
+		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
+		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText"/>
 
-	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
+		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed"/>
+		<exclude name="Generic.WhiteSpace.ScopeIndent"/>
 
-	<!-- Include the WordPress ruleset, with space for exclusions if necessary. -->
-	<rule ref="WordPress-Core">
-		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
-		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
 
-		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
-
-		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />
-		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
-		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
-		<exclude name="Squiz.Commenting.InlineComment.NotCapital" />
+		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+		<exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace"/>
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp"/>
 	</rule>
-	<rule ref="WordPress-Docs">
 
+	<!--
+		Verify that the text_domain is set to the desired text-domain.
+		Multiple valid text domains can be provided as a comma-delimited list.
+	-->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="understrap"/>
+		</properties>
 	</rule>
 
-	<rule ref="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing">
-		<severity>0</severity>
+	<!--
+		Allow for theme specific exceptions to the file name rules based
+		on the theme hierarchy.
+	-->
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="is_theme" value="true"/>
+		</properties>
 	</rule>
+
+	<!-- A closing tag is not permitted at the end of a PHP file -->
+	<!-- <rule ref="Zend.Files.ClosingTag"/> -->
+
+	<!-- Use the PHPCompatibility Ruleset -->
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility">
+		<!--
+			Whitelist PHP native classes, interfaces, functions and constants which
+			are back-filled by WP.
+
+			Based on:
+			* /wp-includes/compat.php
+			* /wp-includes/random_compat/random.php
+		-->
+		<exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
+		<exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
+
+		<exclude name="PHPCompatibility.PHP.NewConstants.json_pretty_printFound"/>
+		<exclude name="PHPCompatibility.PHP.NewConstants.php_version_idFound"/>
+
+		<exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
+		<exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
+		<exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
+		<exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
+		<exclude name="PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound"/>
+
+		<exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
+	</rule>
+
 </ruleset>

--- a/search.php
+++ b/search.php
@@ -75,4 +75,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #search-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/sidebar-templates/sidebar-footerfull.php
+++ b/sidebar-templates/sidebar-footerfull.php
@@ -30,4 +30,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 	</div><!-- #wrapper-footer-full -->
 
-<?php endif; ?>
+<?php endif;

--- a/sidebar-templates/sidebar-hero.php
+++ b/sidebar-templates/sidebar-hero.php
@@ -43,4 +43,4 @@ defined( 'ABSPATH' ) || exit;
 	jQuery( ".carousel-item" ).first().addClass( "active" );
 	</script>
 
-<?php endif; ?>
+<?php endif;

--- a/sidebar-templates/sidebar-herocanvas.php
+++ b/sidebar-templates/sidebar-herocanvas.php
@@ -15,4 +15,4 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php dynamic_sidebar( 'herocanvas' ); ?>
 
-<?php endif; ?>
+<?php endif;

--- a/sidebar-templates/sidebar-statichero.php
+++ b/sidebar-templates/sidebar-statichero.php
@@ -29,4 +29,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 	</div><!-- #wrapper-static-hero -->
 
-<?php endif; ?>
+<?php endif;

--- a/single.php
+++ b/single.php
@@ -49,4 +49,4 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #single-wrapper -->
 
-<?php get_footer(); ?>
+<?php get_footer();

--- a/woocommerce/cart/cart-empty.php
+++ b/woocommerce/cart/cart-empty.php
@@ -28,4 +28,4 @@ if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 			<?php esc_html_e( 'Return to shop', 'understrap' ); ?>
 		</a>
 	</p>
-<?php endif; ?>
+<?php endif;

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -164,4 +164,4 @@ do_action( 'woocommerce_before_cart' ); ?>
 	?>
 </div>
 
-<?php do_action( 'woocommerce_after_cart' ); ?>
+<?php do_action( 'woocommerce_after_cart' );

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -17,6 +17,7 @@
  * @package WooCommerce/Templates
  * @version 3.6.1
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -83,4 +83,4 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_mini_cart' ); ?>
+<?php do_action( 'woocommerce_after_mini_cart' );

--- a/woocommerce/checkout/form-checkout.php
+++ b/woocommerce/checkout/form-checkout.php
@@ -61,4 +61,4 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 </form>
 
-<?php do_action( 'woocommerce_after_checkout_form', $checkout ); ?>
+<?php do_action( 'woocommerce_after_checkout_form', $checkout );

--- a/woocommerce/myaccount/downloads.php
+++ b/woocommerce/myaccount/downloads.php
@@ -44,4 +44,4 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 	</div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_account_downloads', $has_downloads ); ?>
+<?php do_action( 'woocommerce_after_account_downloads', $has_downloads );

--- a/woocommerce/myaccount/form-edit-account.php
+++ b/woocommerce/myaccount/form-edit-account.php
@@ -73,4 +73,4 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 	<?php do_action( 'woocommerce_edit_account_form_end' ); ?>
 </form>
 
-<?php do_action( 'woocommerce_after_edit_account_form' ); ?>
+<?php do_action( 'woocommerce_after_edit_account_form' );

--- a/woocommerce/myaccount/form-edit-address.php
+++ b/woocommerce/myaccount/form-edit-address.php
@@ -53,4 +53,4 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_edit_account_address_form' ); ?>
+<?php do_action( 'woocommerce_after_edit_account_address_form' );

--- a/woocommerce/myaccount/form-login.php
+++ b/woocommerce/myaccount/form-login.php
@@ -117,4 +117,4 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 </div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_customer_login_form' ); ?>
+<?php do_action( 'woocommerce_after_customer_login_form' );

--- a/woocommerce/myaccount/my-orders.php
+++ b/woocommerce/myaccount/my-orders.php
@@ -84,4 +84,4 @@ if ( $customer_orders ) : ?>
 			<?php endforeach; ?>
 		</tbody>
 	</table>
-<?php endif; ?>
+<?php endif;

--- a/woocommerce/myaccount/my-orders.php
+++ b/woocommerce/myaccount/my-orders.php
@@ -70,7 +70,7 @@ if ( $customer_orders ) : ?>
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
 								<?php
 								$actions = wc_get_account_orders_actions( $order );
-								
+
 								if ( ! empty( $actions ) ) {
 									foreach ( $actions as $key => $action ) {
 										echo '<a href="' . esc_url( $action['url'] ) . '" class="btn btn-outline-primary ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';

--- a/woocommerce/myaccount/navigation.php
+++ b/woocommerce/myaccount/navigation.php
@@ -32,4 +32,4 @@ do_action( 'woocommerce_before_account_navigation' );
 	</div>
 </nav>
 
-<?php do_action( 'woocommerce_after_account_navigation' ); ?>
+<?php do_action( 'woocommerce_after_account_navigation' );

--- a/woocommerce/myaccount/orders.php
+++ b/woocommerce/myaccount/orders.php
@@ -104,4 +104,4 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 	</div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_account_orders', $has_orders ); ?>
+<?php do_action( 'woocommerce_after_account_orders', $has_orders );

--- a/woocommerce/single-product/add-to-cart/simple.php
+++ b/woocommerce/single-product/add-to-cart/simple.php
@@ -51,4 +51,4 @@ if ( $product->is_in_stock() ) : ?>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_form' ); ?>
 
-<?php endif; ?>
+<?php endif;


### PR DESCRIPTION
Following on from PR #995, this updates the phpcs ruleset and fixes some minor errors. I have excluded a bunch of rules that UnderStrap violates to keep this PR small. Each can then be dealt with separately.

I've included one rule that is not part of the WP standard, `Zend.Files.ClosingTag`. Twentyninteen and _s follow this rule, as do many [others](https://stackoverflow.com/questions/4410704/why-would-one-omit-the-close-tag#answer-4499749).