### PR TITLE
Include WPCS translators comment rule

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -30,19 +30,19 @@ if ( ! function_exists( 'understrap_add_site_info' ) ) {
 			'<a href="%1$s">%2$s</a><span class="sep"> | </span>%3$s(%4$s)',
 			esc_url( __( 'http://wordpress.org/', 'understrap' ) ),
 			sprintf(
-				/* translators:*/
+				/* translators: WordPress. */
 				esc_html__( 'Proudly powered by %s', 'understrap' ),
 				'WordPress'
 			),
 			sprintf( // WPCS: XSS ok.
-				/* translators:*/
+				/* translators: 1: Theme name, 2: Theme author. */
 				esc_html__( 'Theme: %1$s by %2$s.', 'understrap' ),
 				$the_theme->get( 'Name' ),
 				'<a href="' . esc_url( __( 'http://understrap.com', 'understrap' ) ) . '">understrap.com</a>'
 			),
 			sprintf( // WPCS: XSS ok.
-				/* translators:*/
-				esc_html__( 'Version: %1$s', 'understrap' ),
+				/* translators: Theme version. */
+				esc_html__( 'Version: %s', 'understrap' ),
 				$the_theme->get( 'Version' )
 			)
 		);

--- a/loop-templates/content-none.php
+++ b/loop-templates/content-none.php
@@ -15,32 +15,45 @@ defined( 'ABSPATH' ) || exit;
 
 	<header class="page-header">
 
-		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'understrap' ); ?></h1>
+		<h1 class="page-title"><?php _e( 'Nothing Found', 'understrap' ); ?></h1>
 
 	</header><!-- .page-header -->
 
 	<div class="page-content">
 
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
+		if ( is_home() && current_user_can( 'publish_posts' ) ) :
 
-			<p><?php printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'understrap' ), array(
-	'a' => array(
-		'href' => array(),
-	),
-) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			printf(
+				'<p>' . wp_kses(
+					/* translators: 1: link to WP admin new post page. */
+					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'understrap' ),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				) . '</p>',
+				esc_url( admin_url( 'post-new.php' ) )
+			);
 
-		<?php elseif ( is_search() ) : ?>
+		elseif ( is_search() ) :
+			?>
 
-			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'understrap' ); ?></p>
+			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'understrap' ); ?></p>
 			<?php
-				get_search_form();
-		else : ?>
+			get_search_form();
 
-			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'understrap' ); ?></p>
+		else :
+			?>
+
+			<p><?php _e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'understrap' ); ?></p>
 			<?php
-				get_search_form();
-		endif; ?>
+			get_search_form();
+
+		endif;
+		?>
+
 	</div><!-- .page-content -->
 
 </section><!-- .no-results -->

--- a/loop-templates/content-none.php
+++ b/loop-templates/content-none.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<header class="page-header">
 
-		<h1 class="page-title"><?php _e( 'Nothing Found', 'understrap' ); ?></h1>
+		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'understrap' ); ?></h1>
 
 	</header><!-- .page-header -->
 
@@ -40,14 +40,14 @@ defined( 'ABSPATH' ) || exit;
 		elseif ( is_search() ) :
 			?>
 
-			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'understrap' ); ?></p>
+			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'understrap' ); ?></p>
 			<?php
 			get_search_form();
 
 		else :
 			?>
 
-			<p><?php _e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'understrap' ); ?></p>
+			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'understrap' ); ?></p>
 			<?php
 			get_search_form();
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -33,7 +33,6 @@
 		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
 		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
-		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
 		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText"/>
 
 		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>


### PR DESCRIPTION
This includes the WPCS [translators comment](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#descriptions) rule and formats `content-none.php`.