### PR TITLE
Wpcs i18n string literal

### DIFF
--- a/author.php
+++ b/author.php
@@ -61,35 +61,35 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 				</header><!-- .page-header -->
 
-				<ul>
+				<!-- The Loop -->
+				<?php if ( have_posts() ) : ?>
 
-					<!-- The Loop -->
-					<?php if ( have_posts() ) : ?>
-						<?php while ( have_posts() ) : the_post(); ?>
-							<li>
-								<?php
-								printf(
-									'<a rel="bookmark" href="%1$s" title="%2$s %3$s">%3$s</a>',
-									esc_url( apply_filters( 'the_permalink', get_permalink( $post ), $post ) ),
-									esc_attr( __( 'Permanent Link:', 'understrap' ) ),
-									the_title( '', '', false )
-								);
-								?>
-								<?php understrap_posted_on(); ?>
-								<?php esc_html_e( 'in', 'understrap' ); ?>
-								<?php the_category( '&' ); ?>
-							</li>
-						<?php endwhile; ?>
+					<ul>
 
-					<?php else : ?>
+					<?php while ( have_posts() ) : the_post(); ?>
+						<li>
+							<?php
+							printf(
+								'<a rel="bookmark" href="%1$s" title="%2$s %3$s">%3$s</a>',
+								esc_url( apply_filters( 'the_permalink', get_permalink( $post ), $post ) ),
+								esc_attr( __( 'Permanent Link:', 'understrap' ) ),
+								the_title( '', '', false )
+							);
+							?>
+							<?php understrap_posted_on(); ?>
+							<?php esc_html_e( 'in', 'understrap' ); ?>
+							<?php the_category( '&' ); ?>
+						</li>
+					<?php endwhile; ?>
 
-						<?php get_template_part( 'loop-templates/content', 'none' ); ?>
+					</ul>
 
-					<?php endif; ?>
+				<?php else : ?>
 
-					<!-- End Loop -->
+					<?php get_template_part( 'loop-templates/content', 'none' ); ?>
 
-				</ul>
+				<?php endif; ?>
+				<!-- End Loop -->
 
 			</main><!-- #main -->
 

--- a/author.php
+++ b/author.php
@@ -52,7 +52,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 							<?php if ( ! empty( $curauth->user_description ) ) : ?>
 								<dt><?php esc_html_e( 'Profile', 'understrap' ); ?></dt>
-								<dd><?php esc_html_e( $curauth->user_description, 'understrap' ); ?></dd>
+								<dd><?php echo esc_html( $curauth->user_description ); ?></dd>
 							<?php endif; ?>
 						</dl>
 					<?php endif; ?>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,7 +34,6 @@
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
 		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
 		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
-		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText"/>
 
 		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed"/>


### PR DESCRIPTION
Translation functions require string literals.

The `content-none.php` template does not need to be nested in the `<ul>` tag.