### PR TITLE
Update gulpconfig.json to make watch-bs task work

### DIFF
--- a/gulpconfig.json
+++ b/gulpconfig.json
@@ -3,7 +3,9 @@
 		"proxy": "localhost:8080/",
 		"notify": false
 	},
-	"browserSyncWatchFiles": ["./css/*.min.css", "./js/*.min.js", "./**/*.php"],
+	"browserSyncWatchFiles": {
+		"files": ["./css/*.min.css", "./js/*.min.js", "./**/*.php"]
+	},
 	"paths": {
 		"js": "./js",
 		"css": "./css",


### PR DESCRIPTION
Browser-sync expects an object as its init() config. browserSyncWatchFiles is currently an array, but has to be an object to include "files."