### PR TITLE
Body attributes

### DIFF
--- a/header.php
+++ b/header.php
@@ -26,7 +26,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 <div class="site" id="page">
 
 	<!-- ******************* The Navbar Area ******************* -->
-	<div id="wrapper-navbar" itemscope itemtype="http://schema.org/WebSite">
+	<div id="wrapper-navbar">
 
 		<a class="skip-link sr-only sr-only-focusable" href="#content"><?php esc_html_e( 'Skip to content', 'understrap' ); ?></a>
 

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 	<?php wp_head(); ?>
 </head>
 
-<body <?php body_class(); ?>>
+<body <?php body_class(); ?> <?php understrap_body_attributes(); ?>>
 <?php do_action( 'wp_body_open' ); ?>
 <div class="site" id="page">
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -133,3 +133,18 @@ if ( ! function_exists( 'understrap_mobile_web_app_meta' ) ) {
 	}
 }
 add_action( 'wp_head', 'understrap_mobile_web_app_meta' );
+
+if ( ! function_exists( 'understrap_default_body_attributes' ) ) {
+	/**
+	 * Adds schema markup to the body element.
+	 *
+	 * @param array $atts An associative array of attributes.
+	 * @return array
+	 */
+	function understrap_default_body_attributes( $atts ) {
+		$atts['itemscope'] = '';
+		$atts['itemtype']  = 'http://schema.org/WebSite';
+		return $atts;
+	}
+}
+add_filter( 'understrap_body_attributes', 'understrap_default_body_attributes' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -45,7 +45,6 @@ if ( ! function_exists( 'understrap_posted_on' ) ) {
 	}
 }
 
-
 /**
  * Prints HTML with meta information for the categories, tags and comments.
  */
@@ -83,7 +82,6 @@ if ( ! function_exists( 'understrap_entry_footer' ) ) {
 	}
 }
 
-
 /**
  * Returns true if a blog has more than 1 category.
  *
@@ -113,7 +111,6 @@ if ( ! function_exists( 'understrap_categorized_blog' ) ) {
 	}
 }
 
-
 /**
  * Flush out the transients used in understrap_categorized_blog.
  */
@@ -127,5 +124,31 @@ if ( ! function_exists( 'understrap_category_transient_flusher' ) ) {
 		}
 		// Like, beat it. Dig?
 		delete_transient( 'understrap_categories' );
+	}
+}
+
+if ( ! function_exists( 'understrap_body_attributes' ) ) {
+	/**
+	 * Displays the attributes for the body element.
+	 */
+	function understrap_body_attributes() {
+		/**
+		 * Filters the body attributes.
+		 *
+		 * @param array $atts An associative array of attributes.
+		 */
+		$atts = array_unique( apply_filters( 'understrap_body_attributes', $atts = array() ) );
+		if ( ! is_array( $atts ) || empty( $atts ) ) {
+			return;
+		}
+		$attributes = '';
+		foreach ( $atts as $name => $value ) {
+			if ( $value ) {
+				$attributes .= sanitize_key( $name ) . '="' . esc_attr( $value ) . '" ';
+			} else {
+				$attributes .= sanitize_key( $name ) . ' ';
+			}
+		}
+		echo trim( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }


### PR DESCRIPTION
Adds the function `understrap_body_attributes()` and the filter `understrap_body_attributes` . Attributes, e.g. data attributes for scrollspy, may be added to the body element using the filter.

Removes the schema markup from the `div#wrapper-navbar` element. Adds the schema markup to the `body` by hooking into `understrap_body_attributes` filter.