### PR TITLE
Modify understrap_pagination ul class

### DIFF
--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -35,7 +35,7 @@ if ( ! function_exists( 'understrap_pagination' ) ) {
 
 		<nav aria-label="<?php echo $args['screen_reader_text']; ?>">
 
-			<ul class="pagination">
+			<ul class="<?php echo esc_attr($class); ?>">
 
 				<?php
 				foreach ( $links as $key => $link ) {


### PR DESCRIPTION
The second parameter passed to the function understrap_pagination() was not being utilized.  I have made it output any classes passed to the class tag of the list.