### PR TITLE
Improve accessibility for pagination

### DIFF
--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -33,7 +33,11 @@ if ( ! function_exists( 'understrap_pagination' ) ) {
 
 		?>
 
-		<nav aria-label="<?php echo $args['screen_reader_text']; ?>">
+		<nav aria-labelledby="posts-nav-label">
+
+			<h2 id="posts-nav-label" class="sr-only">
+				<?php echo esc_html( $args['screen_reader_text'] ); ?>
+			</h2>
 
 			<ul class="<?php echo esc_attr( $class ); ?>">
 

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -9,7 +9,36 @@
 defined( 'ABSPATH' ) || exit;
 
 if ( ! function_exists( 'understrap_pagination' ) ) {
-
+	/**
+	 * Displays the navigation to next/previous set of posts.
+	 *
+	 * @param string|array $args {
+	 *     (Optional) Array of arguments for generating paginated links for archives.
+	 *
+	 *     @type string $base               Base of the paginated url. Default empty.
+	 *     @type string $format             Format for the pagination structure. Default empty.
+	 *     @type int    $total              The total amount of pages. Default is the value WP_Query's
+	 *                                      `max_num_pages` or 1.
+	 *     @type int    $current            The current page number. Default is 'paged' query var or 1.
+	 *     @type string $aria_current       The value for the aria-current attribute. Possible values are 'page',
+	 *                                      'step', 'location', 'date', 'time', 'true', 'false'. Default is 'page'.
+	 *     @type bool   $show_all           Whether to show all pages. Default false.
+	 *     @type int    $end_size           How many numbers on either the start and the end list edges.
+	 *                                      Default 1.
+	 *     @type int    $mid_size           How many numbers to either side of the current pages. Default 2.
+	 *     @type bool   $prev_next          Whether to include the previous and next links in the list. Default true.
+	 *     @type bool   $prev_text          The previous page text. Default '&laquo;'.
+	 *     @type bool   $next_text          The next page text. Default '&raquo;'.
+	 *     @type string $type               Controls format of the returned value. Possible values are 'plain',
+	 *                                      'array' and 'list'. Default is 'array'.
+	 *     @type array  $add_args           An array of query args to add. Default false.
+	 *     @type string $add_fragment       A string to append to each link. Default empty.
+	 *     @type string $before_page_number A string to appear before the page number. Default empty.
+	 *     @type string $after_page_number  A string to append after the page number. Default empty.
+	 *     @type string $screen_reader_text Screen reader text for the nav element. Default 'Posts navigation'.
+	 * }
+	 * @param string       $class           (Optional) Classes to be added to the <ul> element. Default 'pagination'.
+	 */
 	function understrap_pagination( $args = array(), $class = 'pagination' ) {
 
 		if ( $GLOBALS['wp_query']->max_num_pages <= 1 ) {
@@ -23,9 +52,9 @@ if ( ! function_exists( 'understrap_pagination' ) ) {
 				'prev_next'          => true,
 				'prev_text'          => __( '&laquo;', 'understrap' ),
 				'next_text'          => __( '&raquo;', 'understrap' ),
-				'screen_reader_text' => __( 'Posts navigation', 'understrap' ),
 				'type'               => 'array',
 				'current'            => max( 1, get_query_var( 'paged' ) ),
+				'screen_reader_text' => __( 'Posts navigation', 'understrap' ),
 			)
 		);
 
@@ -58,5 +87,3 @@ if ( ! function_exists( 'understrap_pagination' ) ) {
 		<?php
 	}
 }
-
-

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -35,7 +35,7 @@ if ( ! function_exists( 'understrap_pagination' ) ) {
 
 		<nav aria-label="<?php echo $args['screen_reader_text']; ?>">
 
-			<ul class="<?php echo esc_attr($class); ?>">
+			<ul class="<?php echo esc_attr( $class ); ?>">
 
 				<?php
 				foreach ( $links as $key => $link ) {


### PR DESCRIPTION
Main:
* Use `aria-labelledby` + heading instead of `aria-label`. (For a discussion see #1063.)

Plus:
* Coding Standards (DocBlock, space usage)