### PR TITLE
Update to Bootstrap 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://understrap.com",
   "dependencies": {
     "@babel/preset-env": "^7.4.5",
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^4.4.1",
     "browser-sync": "^2.26.7",
     "del": "^4.1.0",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
Version 4.4.0 was released on 26th Nov - See https://blog.getbootstrap.com/2019/11/26/bootstrap-4-4-0/
Version 4.4.1 was released on 28th Nov - See https://blog.getbootstrap.com/2019/11/28/bootstrap-4-4-1/