### PR TITLE
Update understrap_post_nav()

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -222,3 +222,25 @@ if ( ! function_exists( 'understrap_kses_title' ) ) {
 		return wp_kses( $data, $allowed_tags );
 	}
 } // End of if function_exists( 'understrap_kses_title' ).
+if ( ! function_exists( 'understrap_post_nav_link_class' ) ) {
+	/**
+	 * Adds CSS class to a post navigation link.
+	 *
+	 * @param string  $output   HTML markup for the adjacent post link..
+	 * @param string  $format   Link anchor format.
+	 * @param string  $link     Link permalink format.
+	 * @param WP_Post $post     The adjacent post.
+	 * @param string  $adjacent Whether the post is previous or next.
+	 * @return string
+	 */
+	function understrap_post_nav_link_class( $output, $format, $link, $post, $adjacent ) {
+		if ( 'previous' === $adjacent ) {
+			$output = str_replace( '<a ', '<a class="nav-link nav-previous pl-0"', $output );
+		} else {
+			$output = str_replace( '<a ', '<a class="nav-link nav-next pr-0"', $output );
+		}
+		return $output;
+	}
+}
+add_filter( 'next_post_link', 'understrap_post_nav_link_class', 20, 5 );
+add_filter( 'previous_post_link', 'understrap_post_nav_link_class', 20, 5 );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -235,9 +235,9 @@ if ( ! function_exists( 'understrap_post_nav_link_class' ) ) {
 	 */
 	function understrap_post_nav_link_class( $output, $format, $link, $post, $adjacent ) {
 		if ( 'previous' === $adjacent ) {
-			$output = str_replace( '<a ', '<a class="nav-link nav-previous pl-0"', $output );
+			$output = str_replace( '<a ', '<a class="nav-link nav-previous pl-0" ', $output );
 		} else {
-			$output = str_replace( '<a ', '<a class="nav-link nav-next pr-0"', $output );
+			$output = str_replace( '<a ', '<a class="nav-link nav-next pr-0" ', $output );
 		}
 		return $output;
 	}

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -79,36 +79,6 @@ if ( ! function_exists( 'understrap_change_logo_class' ) ) {
 	}
 }
 
-if ( ! function_exists( 'understrap_post_nav' ) ) {
-	/**
-	 * Display navigation to next/previous post when applicable.
-	 */
-	function understrap_post_nav() {
-		// Don't print empty markup if there's nowhere to navigate.
-		$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );
-		$next     = get_adjacent_post( false, '', false );
-
-		if ( ! $next && ! $previous ) {
-			return;
-		}
-		?>
-		<nav class="container navigation post-navigation">
-			<h2 class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
-			<div class="row nav-links justify-content-between">
-				<?php
-				if ( get_previous_post_link() ) {
-					previous_post_link( '<span class="nav-previous">%link</span>', _x( '<i class="fa fa-angle-left"></i>&nbsp;%title', 'Previous post link', 'understrap' ) );
-				}
-				if ( get_next_post_link() ) {
-					next_post_link( '<span class="nav-next">%link</span>', _x( '%title&nbsp;<i class="fa fa-angle-right"></i>', 'Next post link', 'understrap' ) );
-				}
-				?>
-			</div><!-- .nav-links -->
-		</nav><!-- .navigation -->
-		<?php
-	}
-}
-
 if ( ! function_exists( 'understrap_pingback' ) ) {
 	/**
 	 * Add a pingback url auto-discovery header for single posts of any post type.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,3 +158,34 @@ if ( ! function_exists( 'understrap_body_attributes' ) ) {
 		echo trim( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }
+
+/**
+ * Display navigation to next/previous post when applicable.
+ */
+
+if ( ! function_exists( 'understrap_post_nav' ) ) {
+	function understrap_post_nav() {
+		// Don't print empty markup if there's nowhere to navigate.
+		$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );
+		$next     = get_adjacent_post( false, '', false );
+
+		if ( ! $next && ! $previous ) {
+			return;
+		}
+		?>
+		<nav class="container navigation post-navigation">
+			<h2 class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
+			<div class="row nav-links justify-content-between">
+				<?php
+				if ( get_previous_post_link() ) {
+					previous_post_link( '<span class="nav-previous">%link</span>', _x( '<i class="fa fa-angle-left"></i>&nbsp;%title', 'Previous post link', 'understrap' ) );
+				}
+				if ( get_next_post_link() ) {
+					next_post_link( '<span class="nav-next">%link</span>', _x( '%title&nbsp;<i class="fa fa-angle-right"></i>', 'Next post link', 'understrap' ) );
+				}
+				?>
+			</div><!-- .nav-links -->
+		</nav><!-- .navigation -->
+		<?php
+	}
+}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -172,9 +172,8 @@ if ( ! function_exists( 'understrap_post_nav' ) ) {
 			return;
 		}
 		?>
-		<nav class="container navigation post-navigation" aria-labelledby="post-nav-label">
+		<nav class="container nav navigation post-navigation justify-content-between" aria-labelledby="post-nav-label">
 			<h2 id="post-nav-label" class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
-			<div class="row nav-links justify-content-between">
 				<?php
 				if ( get_previous_post_link() ) {
 					previous_post_link( '<span class="nav-previous">%link</span>', '<i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;%title' );
@@ -183,7 +182,6 @@ if ( ! function_exists( 'understrap_post_nav' ) ) {
 					next_post_link( '<span class="nav-next">%link</span>', '%title&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i>' );
 				}
 				?>
-			</div><!-- .nav-links -->
 		</nav><!-- .navigation -->
 		<?php
 	}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -159,11 +159,10 @@ if ( ! function_exists( 'understrap_body_attributes' ) ) {
 	}
 }
 
-/**
- * Display navigation to next/previous post when applicable.
- */
-
 if ( ! function_exists( 'understrap_post_nav' ) ) {
+	/**
+	 * Display navigation to next/previous post when applicable.
+	 */
 	function understrap_post_nav() {
 		// Don't print empty markup if there's nowhere to navigate.
 		$previous = ( is_attachment() ) ? get_post( get_post()->post_parent ) : get_adjacent_post( false, '', true );
@@ -178,10 +177,10 @@ if ( ! function_exists( 'understrap_post_nav' ) ) {
 			<div class="row nav-links justify-content-between">
 				<?php
 				if ( get_previous_post_link() ) {
-					previous_post_link( '<span class="nav-previous">%link</span>', _x( '<i class="fa fa-angle-left"></i>&nbsp;%title', 'Previous post link', 'understrap' ) );
+					previous_post_link( '<span class="nav-previous">%link</span>', '<i class="fa fa-angle-left"></i>&nbsp;%title' );
 				}
 				if ( get_next_post_link() ) {
-					next_post_link( '<span class="nav-next">%link</span>', _x( '%title&nbsp;<i class="fa fa-angle-right"></i>', 'Next post link', 'understrap' ) );
+					next_post_link( '<span class="nav-next">%link</span>', '%title&nbsp;<i class="fa fa-angle-right"></i>' );
 				}
 				?>
 			</div><!-- .nav-links -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -172,16 +172,16 @@ if ( ! function_exists( 'understrap_post_nav' ) ) {
 			return;
 		}
 		?>
-		<nav class="container nav navigation post-navigation justify-content-between" aria-labelledby="post-nav-label">
+		<nav class="nav navigation post-navigation justify-content-between" aria-labelledby="post-nav-label">
 			<h2 id="post-nav-label" class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
-				<?php
-				if ( get_previous_post_link() ) {
-					previous_post_link( '%link', '<i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;%title' );
-				}
-				if ( get_next_post_link() ) {
-					next_post_link( '%link', '%title&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i>' );
-				}
-				?>
+			<?php
+			if ( get_previous_post_link() ) {
+				previous_post_link( '%link', '<i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;%title' );
+			}
+			if ( get_next_post_link() ) {
+				next_post_link( '%link', '%title&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i>' );
+			}
+			?>
 		</nav><!-- .navigation -->
 		<?php
 	}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -176,10 +176,10 @@ if ( ! function_exists( 'understrap_post_nav' ) ) {
 			<h2 id="post-nav-label" class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
 				<?php
 				if ( get_previous_post_link() ) {
-					previous_post_link( '<span class="nav-previous">%link</span>', '<i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;%title' );
+					previous_post_link( '%link', '<i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;%title' );
 				}
 				if ( get_next_post_link() ) {
-					next_post_link( '<span class="nav-next">%link</span>', '%title&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i>' );
+					next_post_link( '%link', '%title&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i>' );
 				}
 				?>
 		</nav><!-- .navigation -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -175,14 +175,147 @@ if ( ! function_exists( 'understrap_post_nav' ) ) {
 		<nav class="nav navigation post-navigation justify-content-between" aria-labelledby="post-nav-label">
 			<h2 id="post-nav-label" class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
 			<?php
+			$icon_atts = array(
+				'height' => '0.65rem',
+				'width'  => '0.65rem',
+			);
 			if ( get_previous_post_link() ) {
-				previous_post_link( '%link', '<i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;%title' );
+				previous_post_link( '%link', understrap_bootstrap_icon( 'chevron-left', $icon_atts, false ) . '&nbsp;%title' );
 			}
 			if ( get_next_post_link() ) {
-				next_post_link( '%link', '%title&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i>' );
+				next_post_link( '%link', '%title&nbsp;' . understrap_bootstrap_icon( 'chevron-right', $icon_atts, false ) );
 			}
 			?>
 		</nav><!-- .navigation -->
 		<?php
 	}
 }
+
+if ( ! function_exists( 'understrap_bootstrap_icon' ) ) {
+	/**
+	 * Retrieves or diplays HTML markup for a Bootstrap icon.
+	 *
+	 * @param string   $name Name of the Bootstrap icon as used in the svg class: 'bi bi-name'.
+	 * @param string[] $args (Optional) Associative array of attribute => value pairs for the <svg> tag.
+	 * @param bool     $echo (Optional) Whether to echo (true) or return (return) the svg. Default: true.
+	 * @return string
+	 */
+	function understrap_bootstrap_icon( $name, $args = array(), $echo = true ) {
+
+		// Bootstrap Icons as of v1.0.0-alpha3.
+		$icons = array(
+			'chevron-right' => '<path fill-rule="evenodd" d="M6.646 3.646a.5.5 0 01.708 0l6 6a.5.5 0 010 .708l-6 6a.5.5 0 01-.708-.708L12.293 10 6.646 4.354a.5.5 0 010-.708z" clip-rule="evenodd"/>',
+			'chevron-left'  => '<path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 010 .708L5.707 8l5.647 5.646a.5.5 0 01-.708.708l-6-6a.5.5 0 010-.708l6-6a.5.5 0 01.708 0z" clip-rule="evenodd"/>',
+		);
+
+		/**
+		 * Filters the available Bootstrap icons.
+		 *
+		 * @param string[] $icons Associative array of the Bootstrap icons' HTML excluding the <svg> tag.
+		 */
+		$icons = apply_filters( 'understrap_bootstrap_icons', $icons );
+
+		// Return early if icon does not exist.
+		if ( ! isset( $icons[ $name ] ) ) {
+			return;
+		}
+
+		$default_svg_atts = array(
+			'width'       => '1em',
+			'height'      => '1em',
+			'viewBox'     => '0 0 16 16',
+			'fill'        => 'currentColor',
+			'xmlns'       => 'http://www.w3.org/2000/svg',
+			'focusable'   => 'false',
+			'role'        => 'img',
+			'aria-hidden' => 'true',
+		);
+
+		/**
+		 * Filters the default arguments for Bootstrap icons.
+		 *
+		 * @param string[] $default_svg_atts Associative array of attribute => value pairs for the <svg> tag.
+		 */
+		$default_svg_atts = apply_filters( 'understrap_bootstrap_icon_svg_atts', $default_svg_atts );
+
+		$custom_svg_atts = ! empty( $args ) ? true : false;
+		$atts            = $custom_svg_atts ? wp_parse_args( $args, $default_svg_atts ) : $default_svg_atts;
+
+		if ( isset( $atts['class'] ) ) {
+			$class = ' ' . $atts['class'];
+			unset( $atts['class'] );
+		} else {
+			$class = '';
+		}
+
+		$svg_atts = '';
+		foreach ( $atts as $att => $value ) {
+			switch ( strtolower( $att ) ) {
+				case 'xmlns':
+					$svg_atts .= $att . '="' . esc_url( $value ) . '" ';
+					break;
+				case 'viewbox':
+					$svg_atts .= $att . '="' . $value . '" ';
+					break;
+				default:
+					$svg_atts .= $att . '="' . esc_attr( $value ) . '" ';
+			}
+		}
+		rtrim( $svg_atts );
+
+		$svg = '<svg class="bi bi-' . $name . $class . '" ' . $svg_atts . '>' . $icons[ $name ] . '</svg>';
+		if ( (bool) $echo ) {
+			echo wp_kses( $svg, understrap_allowed_html_svg() );
+		} else {
+			return $svg;
+		}
+	}
+} // End of if function_exists( 'understrap_bootstrap_icon' ).
+
+if ( ! function_exists( 'understrap_get_allowed_html_svg' ) ) {
+	/**
+	 * Retrieves allowed HTML tags and attributes for <svg> tags.
+	 *
+	 * @return array|string[]
+	 */
+	function understrap_get_allowed_html_svg() {
+		$allowed_html = array(
+			'svg'     => array(
+				'class'       => true,
+				'xmlns'       => true,
+				'width'       => true,
+				'height'      => true,
+				'viewbox'     => true,
+				'aria-hidden' => true,
+				'role'        => true,
+				'focusable'   => true,
+			),
+			'path'    => array(
+				'fill'      => true,
+				'fill-rule' => true,
+				'clip-rule' => true,
+				'd'         => true,
+				'transform' => true,
+			),
+			'polygon' => array(
+				'fill'      => true,
+				'fill-rule' => true,
+				'points'    => true,
+				'transform' => true,
+				'focusable' => true,
+			),
+		);
+
+		/**
+		 * Filters the allowed html for svg markup.
+		 *
+		 * @param string[] $allowed_html Associative array of allowed HTML tags and attributes.
+		 */
+		$allowed_html = apply_filters( 'understrap_allowed_html_svg', $allowed_html );
+		if ( ! is_array( $allowed_html ) ) {
+			return array();
+		}
+
+		return $allowed_html;
+	}
+} // End of if function_exists( 'understrap_get_allowed_html_svg' ).

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -172,15 +172,15 @@ if ( ! function_exists( 'understrap_post_nav' ) ) {
 			return;
 		}
 		?>
-		<nav class="container navigation post-navigation">
-			<h2 class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
+		<nav class="container navigation post-navigation" aria-labelledby="post-nav-label">
+			<h2 id="post-nav-label" class="sr-only"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
 			<div class="row nav-links justify-content-between">
 				<?php
 				if ( get_previous_post_link() ) {
-					previous_post_link( '<span class="nav-previous">%link</span>', '<i class="fa fa-angle-left"></i>&nbsp;%title' );
+					previous_post_link( '<span class="nav-previous">%link</span>', '<i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;%title' );
 				}
 				if ( get_next_post_link() ) {
-					next_post_link( '<span class="nav-next">%link</span>', '%title&nbsp;<i class="fa fa-angle-right"></i>' );
+					next_post_link( '<span class="nav-next">%link</span>', '%title&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i>' );
 				}
 				?>
 			</div><!-- .nav-links -->


### PR DESCRIPTION
* Moves the template tag from `inc/extras.php` to `inc/template-tags.php`.
* Removes the translations which are probably there to change the Font Awesome stuff which should not be up to the translator.
* Improves accessibility by adding the attributes `aria-labelledby` and `aria-hidden`.
* Styles the post navigation with Bootstrap's `.nav` and `.nav-link`.

@ Font Awesome: AFAIK this is the only place where the theme uses FA. [theme.scss](https://github.com/understrap/understrap/blob/master/sass/theme.scss) states that the inclusion of FA is optional which it is not unless one enqueues FA in any other way. 
**Needs discussion**: do we really need to use FA there? Wouldn't it be better to provide something like
```scss
.post-navigation .nav-previous { @include caret(left); }
.post-navigation .nav-next { @include caret(right); }
````
to make the exclusion of FA safe by default?

@Thomas-A-Reinert could you please check the accessibility part? Thank you!

_NOTE_: The re-styling part would induce a major version increment. It could break a child theme's styling.