### PR TITLE
Add script and style to theme support for html5

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -62,7 +62,7 @@ if ( ! function_exists( 'understrap_setup' ) ) {
 				'comment-list',
 				'gallery',
 				'caption',
-        'script',
+				'script',
 				'style',
 			)
 		);

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -58,6 +58,8 @@ if ( ! function_exists( 'understrap_setup' ) ) {
 			'comment-list',
 			'gallery',
 			'caption',
+			'script',
+			'style',
 		) );
 
 		/*


### PR DESCRIPTION
In HTML5, the `type` attribute is not required for the `<script>` and `<style>` tags. Including the attribute on these tags (`type="text/javascript"`, for example) will trigger a validation warning in HTML validation tools.

From WordPress 5.3, two new arguments are supported for the `html5` theme feature, `script` and `style`. When these arguments are passed, the `type` attribute will not be output for those tags.

See https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/