### PR TITLE
Add functions for dynamic grid columns

### DIFF
--- a/global-templates/left-sidebar-check.php
+++ b/global-templates/left-sidebar-check.php
@@ -8,11 +8,9 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-$sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
-
+$sidebar_pos = understrap_sidebar_pos();
 if ( 'left' === $sidebar_pos || 'both' === $sidebar_pos ) {
 	get_template_part( 'sidebar-templates/sidebar', 'left' );
 }
 ?>
-
 <div class="col-md content-area" id="primary">

--- a/global-templates/left-sidebar-check.php
+++ b/global-templates/left-sidebar-check.php
@@ -8,9 +8,9 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-$sidebar_pos = understrap_sidebar_pos();
+$sidebar_pos = understrap_get_sidebar_pos();
 if ( 'left' === $sidebar_pos || 'both' === $sidebar_pos ) {
 	get_template_part( 'sidebar-templates/sidebar', 'left' );
 }
 ?>
-<div class="col-md content-area" id="primary">
+<div class="col-md-<?php understrap_content_area_width(); ?> content-area" id="primary">

--- a/global-templates/right-sidebar-check.php
+++ b/global-templates/right-sidebar-check.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 </div><!-- #closing the primary container from /global-templates/left-sidebar-check.php -->
 
 <?php
-$sidebar_pos = understrap_sidebar_pos();
+$sidebar_pos = understrap_get_sidebar_pos();
 if ( 'right' === $sidebar_pos || 'both' === $sidebar_pos ) {
 	get_template_part( 'sidebar-templates/sidebar', 'right' );
 }

--- a/global-templates/right-sidebar-check.php
+++ b/global-templates/right-sidebar-check.php
@@ -12,8 +12,7 @@ defined( 'ABSPATH' ) || exit;
 </div><!-- #closing the primary container from /global-templates/left-sidebar-check.php -->
 
 <?php
-$sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
-
+$sidebar_pos = understrap_sidebar_pos();
 if ( 'right' === $sidebar_pos || 'both' === $sidebar_pos ) {
 	get_template_part( 'sidebar-templates/sidebar', 'right' );
 }

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -159,14 +159,14 @@ if ( ! function_exists( 'understrap_body_attributes' ) ) {
 	}
 }
 
-if ( ! function_exists( 'understrap_sidebar_pos' ) ) {
+if ( ! function_exists( 'understrap_get_sidebar_pos' ) ) {
 	/**
-	 * Retrieve sidebar position.
+	 * Retrieves sidebar position.
 	 *
 	 * @param integer $post (Optional) Post ID or WP_Post object. Default is global $post.
 	 * @return string left|right|both|none
 	 */
-	function understrap_sidebar_pos( $post = 0 ) {
+	function understrap_get_sidebar_pos( $post = 0 ) {
 		$post = get_post( $post );
 		$id   = isset( $post->ID ) ? $post->ID : 0;
 
@@ -207,12 +207,13 @@ if ( ! function_exists( 'understrap_sidebar_pos' ) ) {
 
 if ( ! function_exists( 'understrap_left_sidebar_width' ) ) {
 	/**
-	 * Retrieve left sidebar width.
+	 * Retrieves or displays the left sidebar width.
 	 *
-	 * @param string $pos The position of the sidebars.
+	 * @param string $pos  (Optional) The position of the sidebars.
+	 * @param bool   $echo (Optional) Whether to echo (true = default) or return (false).
 	 * @return int The number of grid columns for the right sidebar.
 	 */
-	function understrap_left_sidebar_width( $pos = 'left' ) {
+	function understrap_left_sidebar_width( $pos = 'left', $echo = true ) {
 		if ( 'left' !== $pos && 'both' !== $pos ) {
 			return 0;
 		}
@@ -228,18 +229,23 @@ if ( ! function_exists( 'understrap_left_sidebar_width' ) ) {
 		 */
 		$width = apply_filters( 'understrap_left_sidebar_width', $pos_width );
 
-		return $width[ $pos ];
+		if ( $echo ) {
+			echo absint( $width[ $pos ] );
+		} else {
+			return $width[ $pos ];
+		}
 	}
 }
 
 if ( ! function_exists( 'understrap_right_sidebar_width' ) ) {
 	/**
-	 * Retrieve left sidebar width.
+	 * Retrieves the right sidebar width.
 	 *
-	 * @param string $pos The position of the sidebars.
-	 * @return int The number of grid columns for the left sidebar.
+	 * @param string $pos  (Optional) The position of the sidebars.
+	 * @param bool   $echo (Optional) Whether to echo (true = default) or return (false).
+	 * @return int The number of grid columns for the right sidebar.
 	 */
-	function understrap_right_sidebar_width( $pos = 'right' ) {
+	function understrap_right_sidebar_width( $pos = 'right', $echo = true ) {
 		if ( 'right' !== $pos && 'both' !== $pos ) {
 			return 0;
 		}
@@ -256,7 +262,47 @@ if ( ! function_exists( 'understrap_right_sidebar_width' ) ) {
 		 */
 		$width = apply_filters( 'understrap_right_sidebar_width', $pos_width );
 
-		return $width[ $pos ];
+		if ( $echo ) {
+			echo absint( $width[ $pos ] );
+		} else {
+			return $width[ $pos ];
+		}
 	}
 }
 
+if ( ! function_exists( 'understrap_content_area_width' ) ) {
+	/**
+	 * Retrieves content area width.
+	 *
+	 * @param int|WP_Post $post (Optional) Post ID or WP_Post object. Default is the global $post.
+	 * @param bool        $echo (Optional) Whether to echo (true = default) or return (false).
+	 * @return int The number of grid columns for the content area.
+	 */
+	function understrap_content_area_width( $post = 0, $echo = true ) {
+		$post = get_post( $post );
+		$id   = isset( $post->ID ) ? $post->ID : 0;
+
+		if ( ! $id ) {
+			return;
+		}
+
+		$pos   = understrap_get_sidebar_pos( $post );
+		$left  = understrap_left_sidebar_width( $pos, false );
+		$right = understrap_right_sidebar_width( $pos, false );
+
+		/**
+		 * Filters the number of grid columns.
+		 *
+		 * @param int|string $grid_columns An integer or numeric string representing the number of grid columns.
+		 */
+		$grid_columns = absint( apply_filters( 'understrap_grid_columns', $grid_columns = 12 ) );
+
+		$width = $grid_columns - $left - $right;
+
+		if ( $echo ) {
+			echo absint( $grid_columns - $left - $right );
+		} else {
+			return $grid_columns - $left - $right;
+		}
+	}
+}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,3 +158,105 @@ if ( ! function_exists( 'understrap_body_attributes' ) ) {
 		echo trim( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }
+
+if ( ! function_exists( 'understrap_sidebar_pos' ) ) {
+	/**
+	 * Retrieve sidebar position.
+	 *
+	 * @param integer $post (Optional) Post ID or WP_Post object. Default is global $post.
+	 * @return string left|right|both|none
+	 */
+	function understrap_sidebar_pos( $post = 0 ) {
+		$post = get_post( $post );
+		$id   = isset( $post->ID ) ? $post->ID : 0;
+
+		if ( ! $id ) {
+			return;
+		}
+
+		$left_active  = is_active_sidebar( 'left-sidebar' ) ? true : false;
+		$right_active = is_active_sidebar( 'right-sidebar' ) ? true : false;
+		$template     = basename( get_page_template( $id ), '.php' );
+
+		switch ( $template ) {
+			case 'right-sidebarpage':
+				$pos = $right_active ? 'right' : 'none';
+				break;
+			case 'left-sidebarpage':
+				$pos = $left_active ? 'left' : 'none';
+				break;
+			case 'both-sidebarspage':
+				if ( $left_active && $right_active ) {
+					$pos = 'both';
+				} elseif ( $left_active xor $right_active ) {
+					$pos = $left_active ? 'left' : 'right';
+				} else {
+					$pos = 'none';
+				}
+				break;
+			case 'fullwidthpage':
+				$pos = 'none';
+				break;
+			default:
+				$pos = get_theme_mod( 'understrap_sidebar_position' );
+		}
+
+		return $pos;
+	}
+}
+
+if ( ! function_exists( 'understrap_left_sidebar_width' ) ) {
+	/**
+	 * Retrieve left sidebar width.
+	 *
+	 * @param string $pos The position of the sidebars.
+	 * @return int The number of grid columns for the right sidebar.
+	 */
+	function understrap_left_sidebar_width( $pos = 'left' ) {
+		if ( 'left' !== $pos && 'both' !== $pos ) {
+			return 0;
+		}
+		$pos_width = array(
+			'left' => 4,
+			'both' => 3,
+		);
+
+		/**
+		 * Filters the array of left sidebar width'.
+		 *
+		 * @param array $pos_width An array of width' for the left sidebar.
+		 */
+		$width = apply_filters( 'understrap_left_sidebar_width', $pos_width );
+
+		return $width[ $pos ];
+	}
+}
+
+if ( ! function_exists( 'understrap_right_sidebar_width' ) ) {
+	/**
+	 * Retrieve left sidebar width.
+	 *
+	 * @param string $pos The position of the sidebars.
+	 * @return int The number of grid columns for the left sidebar.
+	 */
+	function understrap_right_sidebar_width( $pos = 'right' ) {
+		if ( 'right' !== $pos && 'both' !== $pos ) {
+			return 0;
+		}
+
+		$pos_width = array(
+			'right' => 4,
+			'both'  => 3,
+		);
+
+		/**
+		 * Filters the array of right sidebar width'.
+		 *
+		 * @param array $pos_width An array of width' for the right sidebar.
+		 */
+		$width = apply_filters( 'understrap_right_sidebar_width', $pos_width );
+
+		return $width[ $pos ];
+	}
+}
+

--- a/page-templates/both-sidebarspage.php
+++ b/page-templates/both-sidebarspage.php
@@ -20,18 +20,9 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 		<div class="row">
 
-			<?php
-			get_template_part( 'sidebar-templates/sidebar', 'left' );
+			<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
 
-			if ( is_active_sidebar( 'left-sidebar' ) xor is_active_sidebar( 'right-sidebar' ) ) {
-				$class = 'col-md-8';
-			} elseif ( is_active_sidebar( 'left-sidebar' ) && is_active_sidebar( 'right-sidebar' ) ) {
-				$class = 'col-md-4';
-			} else {
-				$class = 'col-md-12';
-			}
-			?>
-			<div class="<?php echo $class; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> content-area" id="primary">
+			<div class="col-md content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 

--- a/page-templates/both-sidebarspage.php
+++ b/page-templates/both-sidebarspage.php
@@ -22,7 +22,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
 
-			<div class="col-md content-area" id="primary">
+			<div class="col-md-<?php understrap_content_area_width(); ?> content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 

--- a/page-templates/left-sidebarpage.php
+++ b/page-templates/left-sidebarpage.php
@@ -22,7 +22,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
 
-			<div class="col-md content-area" id="primary">
+			<div class="col-md-<?php understrap_content_area_width(); ?> content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 

--- a/page-templates/left-sidebarpage.php
+++ b/page-templates/left-sidebarpage.php
@@ -22,7 +22,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
 
-			<div class="<?php echo is_active_sidebar( 'right-sidebar' ) ? 'col-md-8' : 'col-md-12'; ?> content-area" id="primary">
+			<div class="col-md content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 

--- a/page-templates/right-sidebarpage.php
+++ b/page-templates/right-sidebarpage.php
@@ -20,7 +20,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 		<div class="row">
 
-			<div class="<?php echo is_active_sidebar( 'right-sidebar' ) ? 'col-md-8' : 'col-md-12'; ?> content-area" id="primary">
+			<div class="col-md content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 

--- a/page-templates/right-sidebarpage.php
+++ b/page-templates/right-sidebarpage.php
@@ -20,7 +20,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 		<div class="row">
 
-			<div class="col-md content-area" id="primary">
+			<div class="col-md-<?php understrap_content_area_width(); ?> content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 

--- a/sidebar-templates/sidebar-left.php
+++ b/sidebar-templates/sidebar-left.php
@@ -14,11 +14,11 @@ if ( ! is_active_sidebar( 'left-sidebar' ) ) {
 }
 
 // Set sidebar width according to the sidebar position (left or both).
-$sidebar_width = understrap_left_sidebar_width( understrap_sidebar_pos() );
+$sidebar_pos = understrap_get_sidebar_pos();
 
 // Print the sidebar.
 ?>
-<div class="col-md-<?php echo absint( $sidebar_width ); ?> widget-area" id="left-sidebar" role="complementary">
+<div class="col-md-<?php understrap_left_sidebar_width( $sidebar_pos ); ?> widget-area" id="left-sidebar" role="complementary">
 	<?php dynamic_sidebar( 'left-sidebar' ); ?>
 </div><!-- #left-sidebar -->
 <?php

--- a/sidebar-templates/sidebar-left.php
+++ b/sidebar-templates/sidebar-left.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The sidebar containing the main widget area
+ * The left sidebar containing the main widget area
  *
  * @package understrap
  */
@@ -8,19 +8,17 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+// Return early if the sidebar is not active.
 if ( ! is_active_sidebar( 'left-sidebar' ) ) {
 	return;
 }
 
-// when both sidebars turned on reduce col size to 3 from 4.
-$sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
+// Set sidebar width according to the sidebar position (left or both).
+$sidebar_width = understrap_left_sidebar_width( understrap_sidebar_pos() );
+
+// Print the sidebar.
 ?>
-
-<?php if ( 'both' === $sidebar_pos ) : ?>
-	<div class="col-md-3 widget-area" id="left-sidebar" role="complementary">
-<?php else : ?>
-	<div class="col-md-4 widget-area" id="left-sidebar" role="complementary">
-<?php endif; ?>
-<?php dynamic_sidebar( 'left-sidebar' ); ?>
-
+<div class="col-md-<?php echo absint( $sidebar_width ); ?> widget-area" id="left-sidebar" role="complementary">
+	<?php dynamic_sidebar( 'left-sidebar' ); ?>
 </div><!-- #left-sidebar -->
+<?php

--- a/sidebar-templates/sidebar-right.php
+++ b/sidebar-templates/sidebar-right.php
@@ -14,10 +14,10 @@ if ( ! is_active_sidebar( 'right-sidebar' ) ) {
 }
 
 // Set sidebar width according to the sidebar position (right or both).
-$sidebar_width = understrap_right_sidebar_width( understrap_sidebar_pos() );
+$sidebar_pos = understrap_get_sidebar_pos();
 
 // Print the sidebar.
 ?>
-<div class="col-md-<?php echo absint( $sidebar_width ); ?> widget-area" id="right-sidebar" role="complementary">
+<div class="col-md-<?php understrap_right_sidebar_width( $sidebar_pos ); ?> widget-area" id="right-sidebar" role="complementary">
 	<?php dynamic_sidebar( 'right-sidebar' ); ?>
 </div><!-- #right-sidebar -->

--- a/sidebar-templates/sidebar-right.php
+++ b/sidebar-templates/sidebar-right.php
@@ -8,19 +8,16 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+// Return early if the sidebar is not active.
 if ( ! is_active_sidebar( 'right-sidebar' ) ) {
 	return;
 }
 
-// when both sidebars turned on reduce col size to 3 from 4.
-$sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
+// Set sidebar width according to the sidebar position (right or both).
+$sidebar_width = understrap_right_sidebar_width( understrap_sidebar_pos() );
+
+// Print the sidebar.
 ?>
-
-<?php if ( 'both' === $sidebar_pos ) : ?>
-	<div class="col-md-3 widget-area" id="right-sidebar" role="complementary">
-<?php else : ?>
-	<div class="col-md-4 widget-area" id="right-sidebar" role="complementary">
-<?php endif; ?>
-<?php dynamic_sidebar( 'right-sidebar' ); ?>
-
+<div class="col-md-<?php echo absint( $sidebar_width ); ?> widget-area" id="right-sidebar" role="complementary">
+	<?php dynamic_sidebar( 'right-sidebar' ); ?>
 </div><!-- #right-sidebar -->


### PR DESCRIPTION
Adds
* understrap_get_sidebar_pos()
* understrap_left_sidebar_width()
* understrap_right_sidebar_width()
* understrap_content_area_width()

`understrap_get_sidebar_pos()` checks the sidebar position given the default sidebar position, the page template and whether the sidebars are active.
`understrap_left_sidebar_width()` and `understrap_right_sidebar_width()` set the width of the sidebar, i.e. number of grid columns, according to the sidebar position.
`understrap_content_area_width()` sets the width of the content area corresponding to the width of the sidebar(s).

Also, makes sidebar width and the number of grid columns filterable.

Fixes #1146 