### PR TITLE
Deprecate understrap_adjust_body_class()

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -8,6 +8,28 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
+	/**
+	 * Setup body classes.
+	 *
+	 * @param string $classes CSS classes.
+	 *
+	 * @deprecated 0.9.4 Styling of tag has been removed in Bootstrap v4 Alpha 6.
+	 * @link https://github.com/twbs/bootstrap/issues/20939
+	 */
+	function understrap_adjust_body_class( $classes ) {
+
+		foreach ( $classes as $key => $value ) {
+			if ( 'tag' == $value ) {
+				unset( $classes[ $key ] );
+			}
+		}
+
+		return $classes;
+
+	}
+}
+
 if ( ! function_exists( 'understrap_slbd_count_widgets' ) ) {
 	/**
 	 * Count number of widgets in a sidebar

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -34,28 +34,12 @@ if ( ! function_exists( 'understrap_body_classes' ) ) {
 	}
 }
 
-// Removes tag class from the body_class array to avoid Bootstrap markup styling issues.
-add_filter( 'body_class', 'understrap_adjust_body_class' );
-
-if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
-	/**
-	 * Setup body classes.
-	 *
-	 * @param string $classes CSS classes.
-	 *
-	 * @return mixed
+if ( function_exists( 'understrap_adjust_body_class' ) ) {
+	/*
+	 * understrap_adjust_body_class() deprecated in v0.9.4. We keep adding the
+	 * filter for child themes which use their own understrap_adjust_body_class.
 	 */
-	function understrap_adjust_body_class( $classes ) {
-
-		foreach ( $classes as $key => $value ) {
-			if ( 'tag' == $value ) {
-				unset( $classes[ $key ] );
-			}
-		}
-
-		return $classes;
-
-	}
+	add_filter( 'body_class', 'understrap_adjust_body_class' );
 }
 
 // Filter custom logo with correct classes.


### PR DESCRIPTION
As of v4 Alpha 6 Bootstrap no longer styles the `.tag` class.

See shiplist: https://github.com/twbs/bootstrap/issues/20939