### PR TITLE
Update comments

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -49,7 +49,7 @@ if ( post_password_required() ) {
 							'understrap'
 						)
 					),
-					number_format_i18n( '$comments_number' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					number_format_i18n( $comments_number ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					'<span>' . get_the_title() . '</span>'
 				);
 			}

--- a/comments.php
+++ b/comments.php
@@ -38,16 +38,18 @@ if ( post_password_required() ) {
 					'<span>' . get_the_title() . '</span>'
 				);
 			} else {
-				printf( // WPCS: XSS OK.
-					/* translators: 1: number of comments, 2: post title */
-					esc_html( _nx(
-						'%1$s thought on &ldquo;%2$s&rdquo;',
-						'%1$s thoughts on &ldquo;%2$s&rdquo;',
-						$comments_number,
-						'comments title',
-						'understrap'
-					) ),
-					number_format_i18n( $comments_number ),
+				printf(
+					esc_html(
+						/* translators: 1: number of comments, 2: post title */
+						_nx(
+							'%1$s thought on &ldquo;%2$s&rdquo;',
+							'%1$s thoughts on &ldquo;%2$s&rdquo;',
+							$comments_number,
+							'comments title',
+							'understrap'
+						)
+					),
+					number_format_i18n( '$comments_number' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					'<span>' . get_the_title() . '</span>'
 				);
 			}
@@ -55,7 +57,7 @@ if ( post_password_required() ) {
 
 		</h2><!-- .comments-title -->
 
-		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through. ?>
+		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through. ?>
 
 			<nav class="comment-navigation" id="comment-nav-above">
 
@@ -75,7 +77,7 @@ if ( post_password_required() ) {
 
 			</nav><!-- #comment-nav-above -->
 
-		<?php endif; // check for comment navigation. ?>
+		<?php endif; // Check for comment navigation. ?>
 
 		<ol class="comment-list">
 
@@ -90,7 +92,7 @@ if ( post_password_required() ) {
 
 		</ol><!-- .comment-list -->
 
-		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through. ?>
+		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through. ?>
 
 			<nav class="comment-navigation" id="comment-nav-below">
 
@@ -110,18 +112,9 @@ if ( post_password_required() ) {
 
 			</nav><!-- #comment-nav-below -->
 
-		<?php endif; // check for comment navigation. ?>
+		<?php endif; // Check for comment navigation. ?>
 
-	<?php endif; // endif have_comments(). ?>
-
-	<?php
-	// If comments are closed and there are comments, let's leave a little note, shall we?
-	if ( ! comments_open() && '0' != get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
-		?>
-
-		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'understrap' ); ?></p>
-
-	<?php endif; ?>
+	<?php endif; // End of if have_comments(). ?>
 
 	<?php comment_form(); // Render comments form. ?>
 

--- a/inc/custom-comments.php
+++ b/inc/custom-comments.php
@@ -63,7 +63,7 @@ add_filter( 'comment_form_defaults', 'understrap_bootstrap_comment_form' );
 
 if ( ! function_exists( 'understrap_bootstrap_comment_form' ) ) {
 	/**
-	 * Builds the form.
+	 * Adds Bootstrap classes to comment form submit button and comment field.
 	 *
 	 * @param string[] $args Comment form arguments and fields.
 	 *

--- a/inc/custom-comments.php
+++ b/inc/custom-comments.php
@@ -8,61 +8,82 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-// Comments form.
+// Add Bootstrap classes to comment form fields.
 add_filter( 'comment_form_default_fields', 'understrap_bootstrap_comment_form_fields' );
 
-/**
- * Creates the comments form.
- *
- * @param string $fields Form fields.
- *
- * @return array
- */
-
 if ( ! function_exists( 'understrap_bootstrap_comment_form_fields' ) ) {
-
+	/**
+	 * Add Bootstrap classes to WP's comment form default fields.
+	 *
+	 * @param array $fields {
+	 *     Default comment fields.
+	 *
+	 *     @type string $author  Comment author field HTML.
+	 *     @type string $email   Comment author email field HTML.
+	 *     @type string $url     Comment author URL field HTML.
+	 *     @type string $cookies Comment cookie opt-in field HTML.
+	 * }
+	 *
+	 * @return array
+	 */
 	function understrap_bootstrap_comment_form_fields( $fields ) {
-		$commenter = wp_get_current_commenter();
-		$req       = get_option( 'require_name_email' );
-		$aria_req  = ( $req ? " aria-required='true'" : '' );
-		$html5     = current_theme_supports( 'html5', 'comment-form' ) ? 1 : 0;
-		$consent  = empty( $commenter['comment_author_email'] ) ? '' : ' checked="checked"';
-		$fields    = array(
-			'author'  => '<div class="form-group comment-form-author"><label for="author">' . __( 'Name',
-					'understrap' ) . ( $req ? ' <span class="required">*</span>' : '' ) . '</label> ' .
-			            '<input class="form-control" id="author" name="author" type="text" value="' . esc_attr( $commenter['comment_author'] ) . '" size="30"' . $aria_req . '></div>',
-			'email'   => '<div class="form-group comment-form-email"><label for="email">' . __( 'Email',
-					'understrap' ) . ( $req ? ' <span class="required">*</span>' : '' ) . '</label> ' .
-			            '<input class="form-control" id="email" name="email" ' . ( $html5 ? 'type="email"' : 'type="text"' ) . ' value="' . esc_attr( $commenter['comment_author_email'] ) . '" size="30"' . $aria_req . '></div>',
-			'url'     => '<div class="form-group comment-form-url"><label for="url">' . __( 'Website',
-					'understrap' ) . '</label> ' .
-			            '<input class="form-control" id="url" name="url" ' . ( $html5 ? 'type="url"' : 'type="text"' ) . ' value="' . esc_attr( $commenter['comment_author_url'] ) . '" size="30"></div>',
-			'cookies' => '<div class="form-group form-check comment-form-cookies-consent"><input class="form-check-input" id="wp-comment-cookies-consent" name="wp-comment-cookies-consent" type="checkbox" value="yes"' . $consent . ' /> ' .
-			         '<label class="form-check-label" for="wp-comment-cookies-consent">' . __( 'Save my name, email, and website in this browser for the next time I comment', 'understrap' ) . '</label></div>',
+
+		$replace = array(
+			'<p class="' => '<div class="form-group ',
+			'<input'     => '<input class="form-control" ',
+			'</p>'       => '</div>',
 		);
+
+		if ( isset( $fields['author'] ) ) {
+			$fields['author'] = strtr( $fields['author'], $replace );
+		}
+		if ( isset( $fields['email'] ) ) {
+			$fields['email'] = strtr( $fields['email'], $replace );
+		}
+		if ( isset( $fields['url'] ) ) {
+			$fields['url'] = strtr( $fields['url'], $replace );
+		}
+
+		$replace = array(
+			'<p class="' => '<div class="form-group form-check ',
+			'<input'     => '<input class="form-check-input" ',
+			'<label'     => '<label class="form-check-label" ',
+			'</p>'       => '</div>',
+		);
+		if ( isset( $fields['cookies'] ) ) {
+			$fields['cookies'] = strtr( $fields['cookies'], $replace );
+		}
 
 		return $fields;
 	}
-} // endif function_exists( 'understrap_bootstrap_comment_form_fields' )
+} // End of if function_exists( 'understrap_bootstrap_comment_form_fields' )
 
+// Add Bootstrap classes to comment form submit button and comment field.
 add_filter( 'comment_form_defaults', 'understrap_bootstrap_comment_form' );
 
-/**
- * Builds the form.
- *
- * @param string $args Arguments for form's fields.
- *
- * @return mixed
- */
-
 if ( ! function_exists( 'understrap_bootstrap_comment_form' ) ) {
-
+	/**
+	 * Builds the form.
+	 *
+	 * @param string[] $args Comment form arguments and fields.
+	 *
+	 * @return string[]
+	 */
 	function understrap_bootstrap_comment_form( $args ) {
-		$args['comment_field'] = '<div class="form-group comment-form-comment">
-	    <label for="comment">' . _x( 'Comment', 'noun', 'understrap' ) . ( ' <span class="required">*</span>' ) . '</label>
-	    <textarea class="form-control" id="comment" name="comment" aria-required="true" cols="45" rows="8"></textarea>
-	    </div>';
-		$args['class_submit']  = 'btn btn-secondary'; // since WP 4.1.
+		$replace = array(
+			'<p class="' => '<div class="form-group ',
+			'<textarea'  => '<textarea class="form-control" ',
+			'</p>'       => '</div>',
+		);
+
+		if ( isset( $args['comment_field'] ) ) {
+			$args['comment_field'] = strtr( $args['comment_field'], $replace );
+		}
+
+		if ( isset( $args['class_submit'] ) ) {
+			$args['class_submit'] = 'btn btn-secondary';
+		}
+
 		return $args;
 	}
-} // endif function_exists( 'understrap_bootstrap_comment_form' )
+} // End of if function_exists( 'understrap_bootstrap_comment_form' ).

--- a/inc/custom-comments.php
+++ b/inc/custom-comments.php
@@ -87,3 +87,20 @@ if ( ! function_exists( 'understrap_bootstrap_comment_form' ) ) {
 		return $args;
 	}
 } // End of if function_exists( 'understrap_bootstrap_comment_form' ).
+
+
+// Add note if comments are closed.
+add_action( 'comment_form_comments_closed', 'understrap_comment_form_comments_closed' );
+
+if ( ! function_exists( 'understrap_comment_form_comments_closed' ) ) {
+	/**
+	 * Displays a note that comments are closed if comments are closed and there are comments.
+	 */
+	function understrap_comment_form_comments_closed() {
+		if ( get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) {
+			?>
+			<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'understrap' ); ?></p>
+			<?php
+		}
+	}
+} // End of if function_exists( 'understrap_comment_form_comments_closed' ).


### PR DESCRIPTION
* The HTML for the comment form fields is outdated. Using the proposed str_replace updates the HTML to WP's default HTML and makes it easier to maintain in the future.
* Use the comment_form_comments_closed to display the notice that comments are closed.
* Minor WPCS fixes.

