### PR TITLE
Fix WPCS errors and warnings + escaping

### DIFF
--- a/404.php
+++ b/404.php
@@ -49,11 +49,11 @@ $container = get_theme_mod( 'understrap_container_type' );
 										<?php
 										wp_list_categories(
 											array(
-												'orderby'    => 'count',
-												'order'      => 'DESC',
+												'orderby'  => 'count',
+												'order'    => 'DESC',
 												'show_count' => 1,
-												'title_li'   => '',
-												'number'     => 10,
+												'title_li' => '',
+												'number'   => 10,
 											)
 										);
 										?>
@@ -86,4 +86,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #error-404-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/archive.php
+++ b/archive.php
@@ -26,19 +26,19 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<main class="site-main" id="main">
 
-				<?php if ( have_posts() ) : ?>
-
+				<?php
+				if ( have_posts() ) {
+					?>
 					<header class="page-header">
 						<?php
 						the_archive_title( '<h1 class="page-title">', '</h1>' );
 						the_archive_description( '<div class="taxonomy-description">', '</div>' );
 						?>
 					</header><!-- .page-header -->
-
-					<?php /* Start the Loop */ ?>
-					<?php while ( have_posts() ) : the_post(); ?>
-
-						<?php
+					<?php
+					// Start the loop.
+					while ( have_posts() ) {
+						the_post();
 
 						/*
 						 * Include the Post-Format-specific template for the content.
@@ -46,28 +46,26 @@ $container = get_theme_mod( 'understrap_container_type' );
 						 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 						 */
 						get_template_part( 'loop-templates/content', get_post_format() );
-						?>
-
-					<?php endwhile; ?>
-
-				<?php else : ?>
-
-					<?php get_template_part( 'loop-templates/content', 'none' ); ?>
-
-				<?php endif; ?>
+					}
+				} else {
+					get_template_part( 'loop-templates/content', 'none' );
+				}
+				?>
 
 			</main><!-- #main -->
 
-			<!-- The pagination component -->
-			<?php understrap_pagination(); ?>
+			<?php
+			// Display the pagination component.
+			understrap_pagination();
+			// Do the right sidebar check.
+			get_template_part( 'global-templates/right-sidebar-check' );
+			?>
 
-			<!-- Do the right sidebar check -->
-			<?php get_template_part( 'global-templates/right-sidebar-check' ); ?>
-
-		</div> <!-- .row -->
+		</div><!-- .row -->
 
 	</div><!-- #content -->
 
-	</div><!-- #archive-wrapper -->
+</div><!-- #archive-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/author.php
+++ b/author.php
@@ -28,8 +28,8 @@ $container = get_theme_mod( 'understrap_container_type' );
 				<header class="page-header author-header">
 
 					<?php
-					if ( isset( $_GET['author_name'] ) ) {
-						$curauth = get_user_by( 'slug', $author_name );
+					if ( get_query_var( 'author_name' ) ) {
+						$curauth = get_user_by( 'slug', get_query_var( 'author_name' ) );
 					} else {
 						$curauth = get_userdata( intval( $author ) );
 					}
@@ -37,9 +37,11 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 					<h1><?php echo esc_html__( 'About:', 'understrap' ) . ' ' . esc_html( $curauth->nickname ); ?></h1>
 
-					<?php if ( ! empty( $curauth->ID ) ) : ?>
-						<?php echo get_avatar( $curauth->ID ); ?>
-					<?php endif; ?>
+					<?php
+					if ( ! empty( $curauth->ID ) ) {
+						echo get_avatar( $curauth->ID );
+					}
+					?>
 
 					<?php if ( ! empty( $curauth->user_url ) || ! empty( $curauth->user_description ) ) : ?>
 						<dl>
@@ -52,41 +54,38 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 							<?php if ( ! empty( $curauth->user_description ) ) : ?>
 								<dt><?php esc_html_e( 'Profile', 'understrap' ); ?></dt>
-								<dd><?php esc_html_e( $curauth->user_description, 'understrap' ); ?></dd>
+								<dd><?php echo esc_html( $curauth->user_description ); ?></dd>
 							<?php endif; ?>
 						</dl>
 					<?php endif; ?>
 
-					<h2><?php echo esc_html( 'Posts by', 'understrap' ) . ' ' . esc_html( $curauth->nickname ); ?>:</h2>
+					<h2><?php echo esc_html__( 'Posts by', 'understrap' ) . ' ' . esc_html( $curauth->nickname ); ?>:</h2>
 
 				</header><!-- .page-header -->
 
 				<ul>
 
 					<!-- The Loop -->
-					<?php if ( have_posts() ) : ?>
-						<?php while ( have_posts() ) : the_post(); ?>
-							<li>
-								<?php
+					<?php
+					if ( have_posts() ) {
+						while ( have_posts() ) {
+							the_post();
+							echo '<li>';
 								printf(
 									'<a rel="bookmark" href="%1$s" title="%2$s %3$s">%3$s</a>',
 									esc_url( apply_filters( 'the_permalink', get_permalink( $post ), $post ) ),
 									esc_attr( __( 'Permanent Link:', 'understrap' ) ),
-									the_title( '', '', false )
+									get_the_title()
 								);
-								?>
-								<?php understrap_posted_on(); ?>
-								<?php esc_html_e( 'in', 'understrap' ); ?>
-								<?php the_category( '&' ); ?>
-							</li>
-						<?php endwhile; ?>
-
-					<?php else : ?>
-
-						<?php get_template_part( 'loop-templates/content', 'none' ); ?>
-
-					<?php endif; ?>
-
+								understrap_posted_on();
+								esc_html_e( 'in', 'understrap' );
+								the_category( '&' );
+							echo '</li>';
+						}
+					} else {
+						get_template_part( 'loop-templates/content', 'none' );
+					}
+					?>
 					<!-- End Loop -->
 
 				</ul>
@@ -105,4 +104,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #author-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/author.php
+++ b/author.php
@@ -62,12 +62,10 @@ $container = get_theme_mod( 'understrap_container_type' );
 					<h2><?php echo esc_html__( 'Posts by', 'understrap' ) . ' ' . esc_html( $curauth->nickname ); ?>:</h2>
 
 				</header><!-- .page-header -->
-
-				<ul>
-
 					<!-- The Loop -->
 					<?php
 					if ( have_posts() ) {
+						echo '<ul>';
 						while ( have_posts() ) {
 							the_post();
 							echo '<li>';
@@ -82,13 +80,12 @@ $container = get_theme_mod( 'understrap_container_type' );
 								the_category( '&' );
 							echo '</li>';
 						}
+						echo '</ul>';
 					} else {
 						get_template_part( 'loop-templates/content', 'none' );
 					}
 					?>
 					<!-- End Loop -->
-
-				</ul>
 
 			</main><!-- #main -->
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "holger1411/understrap",
+	"name": "understrap/understrap",
 	"description": "Combines Automattic´s Underscores Starter Theme and Bootstrap 4",
 	"type": "wordpress-theme",
 	"license": "GPL-2.0",
@@ -9,17 +9,22 @@
 		"theme",
 		"bootstrap"
 	],
-	"homepage": "https://github.com/holger1411/understrap",
+	"homepage": "https://github.com/understrap/understrap",
 	"require": {
-		"composer/installers": "^1.5"
+		"composer/installers": "^1.9",
+		"php": ">=5.6"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-		"wp-coding-standards/wpcs": "^2.1",
-		"phpcompatibility/php-compatibility": "^9.2"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6",
+		"roave/security-advisories": "dev-master",
+		"wptrt/wpthemereview": "^0.2"
 	},
 	"scripts": {
-		"test": ["vendor/bin/phpcs"],
-		"fix": ["vendor/bin/phpcbf"]
+		"check-cs": ["@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -w"],
+		"fix-cs": ["@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"]
+	},
+	"support": {
+		"issues": "https://github.com/understrap/understrap/issues",
+		"source": "https://github.com/understrap/understrap"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e38e340aaa610ed48211f151263555e",
+    "content-hash": "ad43b10fb1995d73959eae985e5b630c",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.6.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "^4.8.36"
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
@@ -65,6 +68,7 @@
                 "Kanboard",
                 "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
                 "Mautic",
                 "Maya",
                 "OXID",
@@ -73,6 +77,7 @@
                 "RadPHP",
                 "SMF",
                 "Thelia",
+                "Whmcs",
                 "WolfCMS",
                 "agl",
                 "aimeos",
@@ -95,6 +100,7 @@
                 "installer",
                 "itop",
                 "joomla",
+                "known",
                 "kohana",
                 "laravel",
                 "lavalite",
@@ -117,6 +123,7 @@
                 "shopware",
                 "silverstripe",
                 "sydes",
+                "sylius",
                 "symfony",
                 "typo3",
                 "wordpress",
@@ -124,22 +131,22 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2018-08-27T06:10:37+00:00"
+            "time": "2020-04-07T06:57:05+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
                 "shasum": ""
             },
             "require": {
@@ -192,20 +199,20 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "time": "2020-01-29T20:22:20+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.2.0",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
-                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
@@ -229,10 +236,6 @@
             ],
             "authors": [
                 {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
-                },
-                {
                     "name": "Wim Godden",
                     "homepage": "https://github.com/wimg",
                     "role": "lead"
@@ -241,6 +244,10 @@
                     "name": "Juliette Reinders Folmer",
                     "homepage": "https://github.com/jrfnl",
                     "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
                 }
             ],
             "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
@@ -250,20 +257,386 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-06-27T19:58:56+00:00"
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2019-11-04T15:17:54+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
+            "name": "roave/security-advisories",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "09afa996c68c18f49e6487b06adcb2ef27da61fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/09afa996c68c18f49e6487b06adcb2ef27da61fa",
+                "reference": "09afa996c68c18f49e6487b06adcb2ef27da61fa",
+                "shasum": ""
+            },
+            "conflict": {
+                "3f/pygmentize": "<1.2",
+                "adodb/adodb-php": "<5.20.12",
+                "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
+                "amphp/http": "<1.0.1",
+                "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6",
+                "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
+                "aws/aws-sdk-php": ">=3,<3.2.1",
+                "bagisto/bagisto": "<0.1.5",
+                "bolt/bolt": "<3.6.10",
+                "brightlocal/phpwhois": "<=4.2.5",
+                "buddypress/buddypress": "<5.1.2",
+                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.5.18|>=3.6,<3.6.15|>=3.7,<3.7.7",
+                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cartalyst/sentry": "<=2.1.6",
+                "centreon/centreon": "<18.10.8|>=19,<19.4.5",
+                "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
+                "codeigniter/framework": "<=3.0.6",
+                "composer/composer": "<=1-alpha.11",
+                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/core": ">=2,<3.5.39",
+                "contao/core-bundle": ">=4,<4.4.46|>=4.5,<4.8.6",
+                "contao/listing-bundle": ">=4,<4.4.8",
+                "datadog/dd-trace": ">=0.30,<0.30.2",
+                "david-garcia/phpwhois": "<=4.3.1",
+                "doctrine/annotations": ">=1,<1.2.7",
+                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+                "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
+                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2",
+                "doctrine/doctrine-bundle": "<1.5.2",
+                "doctrine/doctrine-module": "<=0.7.1",
+                "doctrine/mongodb-odm": ">=1,<1.0.2",
+                "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
+                "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
+                "dolibarr/dolibarr": "<=10.0.6",
+                "dompdf/dompdf": ">=0.6,<0.6.2",
+                "drupal/core": ">=7,<7.69|>=8,<8.7.12|>=8.8,<8.8.4",
+                "drupal/drupal": ">=7,<7.69|>=8,<8.7.12|>=8.8,<8.8.4",
+                "endroid/qr-code-bundle": "<3.4.2",
+                "enshrined/svg-sanitize": "<0.13.1",
+                "erusev/parsedown": "<1.7.2",
+                "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
+                "ezsystems/ezplatform": ">=1.7,<1.7.9.1|>=1.13,<1.13.5.1|>=2.5,<2.5.4",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2",
+                "ezsystems/ezplatform-user": ">=1,<1.0.1",
+                "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.1|>=6,<6.7.9.1|>=6.8,<6.13.6.2|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.6.2",
+                "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.14.1|>=2011,<2017.12.7.2|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3|>=2019.3,<2019.3.4.2",
+                "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
+                "ezyang/htmlpurifier": "<4.1.1",
+                "firebase/php-jwt": "<2",
+                "fooman/tcpdf": "<6.2.22",
+                "fossar/tcpdf-parser": "<6.2.22",
+                "friendsofsymfony/oauth2-php": "<1.3",
+                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+                "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "fuel/core": "<1.8.1",
+                "getgrav/grav": "<1.7-beta.8",
+                "gree/jose": "<=2.2",
+                "gregwar/rst": "<1.0.3",
+                "guzzlehttp/guzzle": ">=4-rc.2,<4.2.4|>=5,<5.3.1|>=6,<6.2.1",
+                "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.42|>=5.6,<5.6.30",
+                "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29",
+                "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/view": ">=7,<7.1.2",
+                "ivankristianto/phpwhois": "<=4.3",
+                "james-heinrich/getid3": "<1.9.9",
+                "joomla/session": "<1.3.1",
+                "jsmitty12/phpwhois": "<5.1",
+                "kazist/phpwhois": "<=4.2.6",
+                "kreait/firebase-php": ">=3.2,<3.8.1",
+                "la-haute-societe/tcpdf": "<6.2.22",
+                "laravel/framework": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.42|>=5.6,<5.6.30|>=7,<7.1.2",
+                "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
+                "league/commonmark": "<0.18.3",
+                "librenms/librenms": "<1.53",
+                "magento/community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
+                "magento/magento1ce": "<1.9.4.3",
+                "magento/magento1ee": ">=1,<1.14.4.3",
+                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
+                "monolog/monolog": ">=1.8,<1.12",
+                "namshi/jose": "<2.2",
+                "onelogin/php-saml": "<2.10.4",
+                "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
+                "openid/php-openid": "<2.3",
+                "oro/crm": ">=1.7,<1.7.4",
+                "oro/platform": ">=1.7,<1.7.4",
+                "padraic/humbug_get_contents": "<1.1.2",
+                "pagarme/pagarme-php": ">=0,<3",
+                "paragonie/random_compat": "<2",
+                "paypal/merchant-sdk-php": "<3.12",
+                "pear/archive_tar": "<1.4.4",
+                "phpfastcache/phpfastcache": ">=5,<5.0.13",
+                "phpmailer/phpmailer": ">=5,<5.2.27|>=6,<6.0.6",
+                "phpmyadmin/phpmyadmin": "<4.9.2",
+                "phpoffice/phpexcel": "<1.8.2",
+                "phpoffice/phpspreadsheet": "<1.8",
+                "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
+                "phpwhois/phpwhois": "<=4.2.5",
+                "phpxmlrpc/extras": "<0.6.1",
+                "pimcore/pimcore": "<6.3",
+                "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/gamification": "<2.3.2",
+                "prestashop/ps_facetedsearch": "<3.4.1",
+                "privatebin/privatebin": "<1.2.2|>=1.3,<1.3.2",
+                "propel/propel": ">=2-alpha.1,<=2-alpha.7",
+                "propel/propel1": ">=1,<=1.7.1",
+                "pusher/pusher-php-server": "<2.2.1",
+                "robrichards/xmlseclibs": "<3.0.4",
+                "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
+                "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
+                "sensiolabs/connect": "<4.2.3",
+                "serluck/phpwhois": "<=4.2.6",
+                "shopware/shopware": "<5.3.7",
+                "silverstripe/admin": ">=1.0.3,<1.0.4|>=1.1,<1.1.1",
+                "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
+                "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
+                "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
+                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/framework": "<4.4.5|>=4.5,<4.5.2",
+                "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.1.2",
+                "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
+                "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
+                "silverstripe/subsites": ">=2,<2.1.1",
+                "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
+                "silverstripe/userforms": "<3",
+                "simple-updates/phpwhois": "<=1",
+                "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
+                "simplesamlphp/simplesamlphp": "<1.18.4",
+                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+                "simplito/elliptic-php": "<1.0.6",
+                "slim/slim": "<2.6",
+                "smarty/smarty": "<3.1.33",
+                "socalnick/scn-social-auth": "<1.15.2",
+                "spoonity/tcpdf": "<6.2.22",
+                "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+                "ssddanbrown/bookstack": "<0.25.3",
+                "stormpath/sdk": ">=0,<9.9.99",
+                "studio-42/elfinder": "<2.1.49",
+                "swiftmailer/swiftmailer": ">=4,<5.4.5",
+                "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+                "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/grid-bundle": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/resource-bundle": "<1.3.13|>=1.4,<1.4.6|>=1.5,<1.5.1|>=1.6,<1.6.3",
+                "sylius/sylius": "<1.3.16|>=1.4,<1.4.12|>=1.5,<1.5.9|>=1.6,<1.6.5",
+                "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
+                "symbiote/silverstripe-versionedfiles": "<=2.0.3",
+                "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/mime": ">=4.3,<4.3.8",
+                "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/polyfill": ">=1,<1.10",
+                "symfony/polyfill-php55": ">=1,<1.10",
+                "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/routing": ">=2,<2.0.19",
+                "symfony/security": ">=2,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/security-bundle": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<2.8.37|>=3,<3.3.17|>=3.4,<3.4.7|>=4,<4.0.7",
+                "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-guard": ">=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/serializer": ">=2,<2.0.11",
+                "symfony/symfony": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/translation": ">=2,<2.0.17",
+                "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
+                "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
+                "tecnickcom/tcpdf": "<6.2.22",
+                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1-beta.1,<2.1.3",
+                "theonedemon/phpwhois": "<=4.2.5",
+                "titon/framework": ">=0,<9.9.99",
+                "truckersmp/phpwhois": "<=4.3.1",
+                "twig/twig": "<1.38|>=2,<2.7",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.30|>=9,<9.5.12|>=10,<10.2.1",
+                "typo3/cms-core": ">=8,<8.7.30|>=9,<9.5.12|>=10,<10.2.1",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
+                "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
+                "ua-parser/uap-php": "<3.8",
+                "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
+                "verot/class.upload.php": "<=1.0.3|>=2,<=2.0.4",
+                "wallabag/tcpdf": "<6.2.22",
+                "willdurand/js-translation-bundle": "<2.1.1",
+                "yii2mod/yii2-cms": "<1.9.2",
+                "yiisoft/yii": ">=1.1.14,<1.1.15",
+                "yiisoft/yii2": "<2.0.15",
+                "yiisoft/yii2-bootstrap": "<2.0.4",
+                "yiisoft/yii2-dev": "<2.0.15",
+                "yiisoft/yii2-elasticsearch": "<2.0.5",
+                "yiisoft/yii2-gii": "<2.0.4",
+                "yiisoft/yii2-jui": "<2.0.4",
+                "yiisoft/yii2-redis": "<2.0.8",
+                "yourls/yourls": "<1.7.4",
+                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
+                "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
+                "zendframework/zend-diactoros": ">=1,<1.8.4",
+                "zendframework/zend-feed": ">=1,<2.10.3",
+                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-http": ">=1,<2.8.1",
+                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+                "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
+                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
+                "zendframework/zend-validator": ">=2.3,<2.3.6",
+                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zendframework": "<2.5.1",
+                "zendframework/zendframework1": "<1.12.20",
+                "zendframework/zendopenid": ">=2,<2.0.2",
+                "zendframework/zendxml": ">=1,<1.0.1",
+                "zetacomponents/mail": "<1.8.2",
+                "zf-commons/zfc-user": "<1.2.2",
+                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+                "zfr/zfr-oauth2-server-module": "<0.1.2"
+            },
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
+                },
+                {
+                    "name": "Ilya Tribusean",
+                    "email": "slash3b@gmail.com",
+                    "role": "maintainer"
+                }
+            ],
+            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+            "time": "2020-04-15T04:56:51+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
             "require": {
@@ -301,20 +674,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "time": "2020-04-17T01:09:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b5a453203114cc2284b1a614c4953456fbe4f546",
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546",
                 "shasum": ""
             },
             "require": {
@@ -322,9 +695,57 @@
                 "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2020-02-04T02:52:06+00:00"
+        },
+        {
+            "name": "wptrt/wpthemereview",
+            "version": "0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WPTRT/WPThemeReview.git",
+                "reference": "462e59020dad9399ed2fe8e61f2a21b5e206e420"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WPTRT/WPThemeReview/zipball/462e59020dad9399ed2fe8e61f2a21b5e206e420",
+                "reference": "462e59020dad9399ed2fe8e61f2a21b5e206e420",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcompatibility/phpcompatibility-wp": "^2.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "wp-coding-standards/wpcs": "^2.2.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "roave/security-advisories": "dev-master"
             },
             "suggest": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -336,24 +757,51 @@
             ],
             "authors": [
                 {
+                    "name": "Theme Review Team",
+                    "homepage": "https://make.wordpress.org/themes/handbook/",
+                    "role": "Strategy and rule setting"
+                },
+                {
+                    "name": "Ulrich Pogson",
+                    "homepage": "https://github.com/grappler",
+                    "role": "Lead developer"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "Lead developer"
+                },
+                {
+                    "name": "Denis Žoljom",
+                    "homepage": "https://github.com/dingo-d",
+                    "role": "Plugin integration lead"
+                },
+                {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WPTRT/WPThemeReview/graphs/contributors"
                 }
             ],
-            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "description": "PHP_CodeSniffer rules (sniffs) to verify theme compliance with the rules for theme hosting on wordpress.org",
+            "homepage": "https://make.wordpress.org/themes/handbook/review/",
             "keywords": [
                 "phpcs",
                 "standards",
+                "themes",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2019-11-17T20:05:55+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "roave/security-advisories": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
+    "platform": {
+        "php": ">=5.6"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,7 @@ $understrap_includes = array(
 	'/customizer.php',                      // Customizer additions.
 	'/custom-comments.php',                 // Custom Comments file.
 	'/jetpack.php',                         // Load Jetpack compatibility file.
-	'/class-wp-bootstrap-navwalker.php',    // Load custom WordPress nav walker. Trying to get deeper navigation? Check out: https://github.com/understrap/understrap/issues/567
+	'/class-wp-bootstrap-navwalker.php',    // Load custom WordPress nav walker. Trying to get deeper navigation? Check out: https://github.com/understrap/understrap/issues/567.
 	'/woocommerce.php',                     // Load WooCommerce functions.
 	'/editor.php',                          // Load Editor functions.
 	'/deprecated.php',                      // Load deprecated functions.

--- a/global-templates/hero.php
+++ b/global-templates/hero.php
@@ -7,18 +7,19 @@
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
-?>
 
-<?php if ( is_active_sidebar( 'hero' ) || is_active_sidebar( 'statichero' ) || is_active_sidebar( 'herocanvas' ) ) : ?>
+if ( is_active_sidebar( 'hero' ) || is_active_sidebar( 'statichero' ) || is_active_sidebar( 'herocanvas' ) ) :
+	?>
 
 	<div class="wrapper" id="wrapper-hero">
 
-		<?php get_template_part( 'sidebar-templates/sidebar', 'hero' ); ?>
-
-		<?php get_template_part( 'sidebar-templates/sidebar', 'herocanvas' ); ?>
-
-		<?php get_template_part( 'sidebar-templates/sidebar', 'statichero' ); ?>
+		<?php
+		get_template_part( 'sidebar-templates/sidebar', 'hero' );
+		get_template_part( 'sidebar-templates/sidebar', 'herocanvas' );
+		get_template_part( 'sidebar-templates/sidebar', 'statichero' );
+		?>
 
 	</div>
 
-<?php endif;
+	<?php
+endif;

--- a/global-templates/left-sidebar-check.php
+++ b/global-templates/left-sidebar-check.php
@@ -9,10 +9,10 @@
 defined( 'ABSPATH' ) || exit;
 
 $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
-?>
 
-<?php if ( 'left' === $sidebar_pos || 'both' === $sidebar_pos ) : ?>
-	<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
-<?php endif; ?>
+if ( 'left' === $sidebar_pos || 'both' === $sidebar_pos ) {
+	get_template_part( 'sidebar-templates/sidebar', 'left' );
+}
+?>
 
 <div class="col-md content-area" id="primary">

--- a/global-templates/right-sidebar-check.php
+++ b/global-templates/right-sidebar-check.php
@@ -11,10 +11,9 @@ defined( 'ABSPATH' ) || exit;
 
 </div><!-- #closing the primary container from /global-templates/left-sidebar-check.php -->
 
-<?php $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' ); ?>
+<?php
+$sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
-<?php if ( 'right' === $sidebar_pos || 'both' === $sidebar_pos ) : ?>
-
-	<?php get_template_part( 'sidebar-templates/sidebar', 'right' ); ?>
-
-<?php endif;
+if ( 'right' === $sidebar_pos || 'both' === $sidebar_pos ) {
+	get_template_part( 'sidebar-templates/sidebar', 'right' );
+}

--- a/header.php
+++ b/header.php
@@ -53,16 +53,20 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 						<?php endif; ?>
 
-					<?php } else {
+						<?php
+					} else {
 						the_custom_logo();
-					} ?><!-- end custom logo -->
+					}
+					?>
+					<!-- end custom logo -->
 
 				<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="<?php esc_attr_e( 'Toggle navigation', 'understrap' ); ?>">
 					<span class="navbar-toggler-icon"></span>
 				</button>
 
 				<!-- The WordPress Menu goes here -->
-				<?php wp_nav_menu(
+				<?php
+				wp_nav_menu(
 					array(
 						'theme_location'  => 'primary',
 						'container_class' => 'collapse navbar-collapse',
@@ -73,7 +77,8 @@ $container = get_theme_mod( 'understrap_container_type' );
 						'depth'           => 2,
 						'walker'          => new Understrap_WP_Bootstrap_Navwalker(),
 					)
-				); ?>
+				);
+				?>
 			<?php if ( 'container' === $container ) : ?>
 			</div><!-- .container -->
 			<?php endif; ?>

--- a/inc/class-wp-bootstrap-navwalker.php
+++ b/inc/class-wp-bootstrap-navwalker.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * GitHub Branch: master
  * License: GPL-3.0+
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
-*/
+ */
 
 /* Check if Class Exists. */
 if ( ! class_exists( 'Understrap_WP_Bootstrap_Navwalker' ) ) {
@@ -182,7 +182,7 @@ if ( ! class_exists( 'Understrap_WP_Bootstrap_Navwalker' ) ) {
 			}
 
 			$atts['target'] = ! empty( $item->target ) ? $item->target : '';
-			if ( '_blank' === $item->target && empty( $item->xfn ) ) { // Thanks to LukaszJaro, see https://github.com/understrap/understrap/issues/973
+			if ( '_blank' === $item->target && empty( $item->xfn ) ) { // Thanks to LukaszJaro, see https://github.com/understrap/understrap/issues/973.
 				$atts['rel'] = 'noopener noreferrer';
 			} else {
 				$atts['rel'] = $item->xfn;
@@ -381,7 +381,7 @@ if ( ! class_exists( 'Understrap_WP_Bootstrap_Navwalker' ) ) {
 
 				// if $args has 'echo' key and it's true echo, otherwise return.
 				if ( array_key_exists( 'echo', $args ) && $args['echo'] ) {
-					echo $fallback_output; // WPCS: XSS OK.
+					echo $fallback_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				} else {
 					return $fallback_output;
 				}

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -11,6 +11,9 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'after_setup_theme', 'understrap_custom_header_setup' );
 
 if ( ! function_exists( 'understrap_custom_header_setup' ) ) {
+	/**
+	 * Set up custom header feature.
+	 */
 	function understrap_custom_header_setup() {
 
 		/**

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -130,7 +130,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 			)
 		);
 	}
-} // endif function_exists( 'understrap_theme_customize_register' ).
+} // End of if function_exists( 'understrap_theme_customize_register' ).
 add_action( 'customize_register', 'understrap_theme_customize_register' );
 
 /**

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -21,26 +21,26 @@ if ( ! function_exists( 'understrap_slbd_count_widgets' ) ) {
 		// to see if wp_convert_widget_settings() has made manipulations in memory.
 		global $_wp_sidebars_widgets;
 		if ( empty( $_wp_sidebars_widgets ) ) :
-			$_wp_sidebars_widgets = get_option( 'sidebars_widgets', array() );
+			$_wp_sidebars_widgets = get_option( 'sidebars_widgets', array() ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		endif;
 		$sidebars_widgets_count = $_wp_sidebars_widgets;
 		if ( isset( $sidebars_widgets_count[ $sidebar_id ] ) ) :
-			$widget_count = count( $sidebars_widgets_count[ $sidebar_id ] );
+			$widget_count   = count( $sidebars_widgets_count[ $sidebar_id ] );
 			$widget_classes = 'widget-count-' . count( $sidebars_widgets_count[ $sidebar_id ] );
-			if ( 0 == $widget_count % 4 || $widget_count > 6 ) :
-				// Four widgets per row if there are exactly four or more than six
+			if ( 0 == $widget_count % 4 || $widget_count > 6 ) : // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+				// Four widgets per row if there are exactly four or more than six.
 				$widget_classes .= ' col-md-3';
-			elseif ( 6 == $widget_count ) :
-				// If two widgets are published
+			elseif ( 6 == $widget_count ) : // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+				// If two widgets are published.
 				$widget_classes .= ' col-md-2';
 			elseif ( $widget_count >= 3 ) :
-				// Three widgets per row if there's three or more widgets
+				// Three widgets per row if there's three or more widgets.
 				$widget_classes .= ' col-md-4';
-			elseif ( 2 == $widget_count ) :
-				// If two widgets are published
+			elseif ( 2 == $widget_count ) : // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+				// If two widgets are published.
 				$widget_classes .= ' col-md-6';
-			elseif ( 1 == $widget_count ) :
-				// If just on widget is active
+			elseif ( 1 == $widget_count ) : // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+				// If just on widget is active.
 				$widget_classes .= ' col-md-12';
 			endif;
 			return $widget_classes;

--- a/inc/editor.php
+++ b/inc/editor.php
@@ -24,7 +24,7 @@ add_filter( 'mce_buttons_2', 'understrap_tiny_mce_style_formats' );
 if ( ! function_exists( 'understrap_tiny_mce_style_formats' ) ) {
 	/**
 	 * Reveals TinyMCE's hidden Style dropdown.
-	 * 
+	 *
 	 * @param array $buttons Array of Tiny MCE's button ids.
 	 * @return array
 	 */

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -28,6 +28,6 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 			wp_enqueue_script( 'comment-reply' );
 		}
 	}
-} // endif function_exists( 'understrap_scripts' ).
+} // End of if function_exists( 'understrap_scripts' ).
 
 add_action( 'wp_enqueue_scripts', 'understrap_scripts' );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -48,7 +48,7 @@ if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
 	function understrap_adjust_body_class( $classes ) {
 
 		foreach ( $classes as $key => $value ) {
-			if ( 'tag' == $value ) {
+			if ( 'tag' === $value ) {
 				unset( $classes[ $key ] );
 			}
 		}
@@ -147,3 +147,108 @@ if ( ! function_exists( 'understrap_default_body_attributes' ) ) {
 	}
 }
 add_filter( 'understrap_body_attributes', 'understrap_default_body_attributes' );
+
+// Escapes all occurances of 'the_archive_description'.
+add_filter( 'get_the_archive_description', 'understrap_escape_the_archive_description' );
+
+if ( ! function_exists( 'understrap_escape_the_archive_description' ) ) {
+	/**
+	 * Escapes the description for an author or post type archive.
+	 *
+	 * @param string $description Archive description.
+	 * @return string Maybe escaped $description.
+	 */
+	function understrap_escape_the_archive_description( $description ) {
+		if ( is_author() || is_post_type_archive() ) {
+			return wp_kses_post( $description );
+		} else {
+			/*
+			* All other descriptions are retrieved via term_description() which returns
+			* a sanitized description.
+			*/
+			return $description;
+		}
+	}
+} // End of if function_exists( 'understrap_escape_the_archive_description' ).
+
+// Escapes all occurances of 'the_title()' and 'get_the_title()'.
+add_filter( 'the_title', 'understrap_kses_title' );
+
+// Escapes all occurances of 'the_archive_title' and 'get_the_archive_title()'.
+add_filter( 'get_the_archive_title', 'understrap_kses_title' );
+
+if ( ! function_exists( 'understrap_kses_title' ) ) {
+	/**
+	 * Sanitizes data for allowed HTML tags for post title.
+	 *
+	 * @param string $data Post title to filter.
+	 * @return string Filtered post title with allowed HTML tags and attributes intact.
+	 */
+	function understrap_kses_title( $data ) {
+		// Tags not supported in HTML5 are not allowed.
+		$allowed_tags = array(
+			'abbr'             => array(),
+			'aria-describedby' => true,
+			'aria-details'     => true,
+			'aria-label'       => true,
+			'aria-labelledby'  => true,
+			'aria-hidden'      => true,
+			'b'                => array(),
+			'bdo'              => array(
+				'dir' => true,
+			),
+			'blockquote'       => array(
+				'cite'     => true,
+				'lang'     => true,
+				'xml:lang' => true,
+			),
+			'cite'             => array(
+				'dir'  => true,
+				'lang' => true,
+			),
+			'dfn'              => array(),
+			'em'               => array(),
+			'i'                => array(
+				'aria-describedby' => true,
+				'aria-details'     => true,
+				'aria-label'       => true,
+				'aria-labelledby'  => true,
+				'aria-hidden'      => true,
+				'class'            => true,
+			),
+			'code'             => array(),
+			'del'              => array(
+				'datetime' => true,
+			),
+			'ins'              => array(
+				'datetime' => true,
+				'cite'     => true,
+			),
+			'kbd'              => array(),
+			'mark'             => array(),
+			'pre'              => array(
+				'width' => true,
+			),
+			'q'                => array(
+				'cite' => true,
+			),
+			's'                => array(),
+			'samp'             => array(),
+			'span'             => array(
+				'dir'      => true,
+				'align'    => true,
+				'lang'     => true,
+				'xml:lang' => true,
+			),
+			'small'            => array(),
+			'strong'           => array(),
+			'sub'              => array(),
+			'sup'              => array(),
+			'u'                => array(),
+			'var'              => array(),
+		);
+		$allowed_tags = apply_filters( 'understrap_kses_title', $allowed_tags );
+
+		return wp_kses( $data, $allowed_tags );
+	}
+} // End of if function_exists( 'understrap_kses_title' ).

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -29,23 +29,23 @@ if ( ! function_exists( 'understrap_add_site_info' ) ) {
 			'<a href="%1$s">%2$s</a><span class="sep"> | </span>%3$s(%4$s)',
 			esc_url( __( 'http://wordpress.org/', 'understrap' ) ),
 			sprintf(
-				/* translators:*/
+				/* translators: WordPress */
 				esc_html__( 'Proudly powered by %s', 'understrap' ),
 				'WordPress'
 			),
 			sprintf( // WPCS: XSS ok.
-				/* translators:*/
+				/* translators: 1: Theme name, 2: Theme author */
 				esc_html__( 'Theme: %1$s by %2$s.', 'understrap' ),
 				$the_theme->get( 'Name' ),
 				'<a href="' . esc_url( __( 'http://understrap.com', 'understrap' ) ) . '">understrap.com</a>'
 			),
 			sprintf( // WPCS: XSS ok.
-				/* translators:*/
+				/* translators: Theme version */
 				esc_html__( 'Version: %1$s', 'understrap' ),
 				$the_theme->get( 'Version' )
 			)
 		);
 
-		echo apply_filters( 'understrap_site_info_content', $site_info ); // WPCS: XSS ok.
+		echo apply_filters( 'understrap_site_info_content', $site_info ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -10,16 +10,16 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-/**
- * Jetpack setup function.
- *
- * See: https://jetpack.me/support/infinite-scroll/
- * See: https://jetpack.me/support/responsive-videos/
- */
-
 add_action( 'after_setup_theme', 'understrap_components_jetpack_setup' );
 
 if ( ! function_exists( 'understrap_components_jetpack_setup' ) ) {
+	/**
+	 * Jetpack setup function.
+	 *
+	 * @link https://jetpack.me/support/infinite-scroll/
+	 * @link https://jetpack.me/support/responsive-videos/
+	 * @link https://jetpack.me/support/social-menu/
+	 */
 	function understrap_components_jetpack_setup() {
 		// Add theme support for Infinite Scroll.
 		add_theme_support(
@@ -34,18 +34,16 @@ if ( ! function_exists( 'understrap_components_jetpack_setup' ) ) {
 		// Add theme support for Responsive Videos.
 		add_theme_support( 'jetpack-responsive-videos' );
 
-		// Add theme support for Social Menus
+		// Add theme support for Social Menus.
 		add_theme_support( 'jetpack-social-menu' );
 
 	}
 }
 
-
-/**
- * Custom render function for Infinite Scroll.
- */
-
 if ( ! function_exists( 'understrap_components_infinite_scroll_render' ) ) {
+	/**
+	 * Custom render function for Infinite Scroll.
+	 */
 	function understrap_components_infinite_scroll_render() {
 		while ( have_posts() ) {
 			the_post();
@@ -59,8 +57,13 @@ if ( ! function_exists( 'understrap_components_infinite_scroll_render' ) ) {
 }
 
 if ( ! function_exists( 'understrap_components_social_menu' ) ) {
+	/**
+	 * Display Jetpack's social menu if available.
+	 * Avoids fatal errors if Jetpack isn’t activated.
+	 */
 	function understrap_components_social_menu() {
 		if ( ! function_exists( 'jetpack_social_menu' ) ) {
+			// Return early if social menu is not available.
 			return;
 		} else {
 			jetpack_social_menu();

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -77,7 +77,7 @@ if ( ! function_exists( 'understrap_pagination' ) ) {
 				foreach ( $links as $key => $link ) {
 					?>
 					<li class="page-item <?php echo strpos( $link, 'current' ) ? 'active' : ''; ?>">
-						<?php echo str_replace( 'page-numbers', 'page-link', $link ); ?>
+						<?php echo str_replace( 'page-numbers', 'page-link', $link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</li>
 					<?php
 				}

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -44,21 +44,26 @@ if ( ! function_exists( 'understrap_setup' ) ) {
 		add_theme_support( 'title-tag' );
 
 		// This theme uses wp_nav_menu() in one location.
-		register_nav_menus( array(
-			'primary' => __( 'Primary Menu', 'understrap' ),
-		) );
+		register_nav_menus(
+			array(
+				'primary' => __( 'Primary Menu', 'understrap' ),
+			)
+		);
 
 		/*
 		 * Switch default core markup for search form, comment form, and comments
 		 * to output valid HTML5.
 		 */
-		add_theme_support( 'html5', array(
-			'search-form',
-			'comment-form',
-			'comment-list',
-			'gallery',
-			'caption',
-		) );
+		add_theme_support(
+			'html5',
+			array(
+				'search-form',
+				'comment-form',
+				'comment-list',
+				'gallery',
+				'caption',
+			)
+		);
 
 		/*
 		 * Adding Thumbnail basic support
@@ -74,19 +79,28 @@ if ( ! function_exists( 'understrap_setup' ) ) {
 		 * Enable support for Post Formats.
 		 * See http://codex.wordpress.org/Post_Formats
 		 */
-		add_theme_support( 'post-formats', array(
-			'aside',
-			'image',
-			'video',
-			'quote',
-			'link',
-		) );
+		add_theme_support(
+			'post-formats',
+			array(
+				'aside',
+				'image',
+				'video',
+				'quote',
+				'link',
+			)
+		);
 
 		// Set up the WordPress core custom background feature.
-		add_theme_support( 'custom-background', apply_filters( 'understrap_custom_background_args', array(
-			'default-color' => 'ffffff',
-			'default-image' => '',
-		) ) );
+		add_theme_support(
+			'custom-background',
+			apply_filters(
+				'understrap_custom_background_args',
+				array(
+					'default-color' => 'ffffff',
+					'default-image' => '',
+				)
+			)
+		);
 
 		// Set up the WordPress Theme logo feature.
 		add_theme_support( 'custom-logo' );
@@ -131,8 +145,10 @@ if ( ! function_exists( 'understrap_all_excerpts_get_more_link' ) ) {
 	 */
 	function understrap_all_excerpts_get_more_link( $post_excerpt ) {
 		if ( ! is_admin() ) {
-			$post_excerpt = $post_excerpt . ' [...]<p><a class="btn btn-secondary understrap-read-more-link" href="' . esc_url( get_permalink( get_the_ID() ) ) . '">' . __( 'Read More...',
-			'understrap' ) . '</a></p>';
+			$post_excerpt = $post_excerpt . ' [...]<p><a class="btn btn-secondary understrap-read-more-link" href="' . esc_url( get_permalink( get_the_ID() ) ) . '">' . __(
+				'Read More...',
+				'understrap'
+			) . '</a></p>';
 		}
 		return $post_excerpt;
 	}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -10,23 +10,25 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-/**
- * Prints HTML with meta information for the current post-date/time and author.
- */
 if ( ! function_exists( 'understrap_posted_on' ) ) {
+	/**
+	 * Prints HTML with meta information for the current post-date/time and author.
+	 */
 	function understrap_posted_on() {
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
 			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s"> (%4$s) </time>';
 		}
-		$time_string = sprintf( $time_string,
+		$time_string = sprintf(
+			$time_string,
 			esc_attr( get_the_date( 'c' ) ),
 			esc_html( get_the_date() ),
 			esc_attr( get_the_modified_date( 'c' ) ),
 			esc_html( get_the_modified_date() )
 		);
 		$posted_on   = apply_filters(
-			'understrap_posted_on', sprintf(
+			'understrap_posted_on',
+			sprintf(
 				'<span class="posted-on">%1$s <a href="%2$s" rel="bookmark">%3$s</a></span>',
 				esc_html_x( 'Posted on', 'post date', 'understrap' ),
 				esc_url( get_permalink() ),
@@ -34,21 +36,22 @@ if ( ! function_exists( 'understrap_posted_on' ) ) {
 			)
 		);
 		$byline      = apply_filters(
-			'understrap_posted_by', sprintf(
+			'understrap_posted_by',
+			sprintf(
 				'<span class="byline"> %1$s<span class="author vcard"> <a class="url fn n" href="%2$s">%3$s</a></span></span>',
 				$posted_on ? esc_html_x( 'by', 'post author', 'understrap' ) : esc_html_x( 'Posted by', 'post author', 'understrap' ),
 				esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 				esc_html( get_the_author() )
 			)
 		);
-		echo $posted_on . $byline; // WPCS: XSS OK.
+		echo $posted_on . $byline; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 
-/**
- * Prints HTML with meta information for the categories, tags and comments.
- */
 if ( ! function_exists( 'understrap_entry_footer' ) ) {
+	/**
+	 * Prints HTML with meta information for the categories, tags and comments.
+	 */
 	function understrap_entry_footer() {
 		// Hide category and tag text for pages.
 		if ( 'post' === get_post_type() ) {
@@ -56,13 +59,13 @@ if ( ! function_exists( 'understrap_entry_footer' ) ) {
 			$categories_list = get_the_category_list( esc_html__( ', ', 'understrap' ) );
 			if ( $categories_list && understrap_categorized_blog() ) {
 				/* translators: %s: Categories of current post */
-				printf( '<span class="cat-links">' . esc_html__( 'Posted in %s', 'understrap' ) . '</span>', $categories_list ); // WPCS: XSS OK.
+				printf( '<span class="cat-links">' . esc_html__( 'Posted in %s', 'understrap' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 			/* translators: used between list items, there is a space after the comma */
 			$tags_list = get_the_tag_list( '', esc_html__( ', ', 'understrap' ) );
 			if ( $tags_list ) {
 				/* translators: %s: Tags of current post */
-				printf( '<span class="tags-links">' . esc_html__( 'Tagged %s', 'understrap' ) . '</span>', $tags_list ); // WPCS: XSS OK.
+				printf( '<span class="tags-links">' . esc_html__( 'Tagged %s', 'understrap' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}
 		if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
@@ -82,21 +85,24 @@ if ( ! function_exists( 'understrap_entry_footer' ) ) {
 	}
 }
 
-/**
- * Returns true if a blog has more than 1 category.
- *
- * @return bool
- */
 if ( ! function_exists( 'understrap_categorized_blog' ) ) {
+	/**
+	 * Returns true if a blog has more than 1 category.
+	 *
+	 * @return bool
+	 */
 	function understrap_categorized_blog() {
-		if ( false === ( $all_the_cool_cats = get_transient( 'understrap_categories' ) ) ) {
+		$all_the_cool_cats = get_transient( 'understrap_categories' );
+		if ( false === $all_the_cool_cats ) {
 			// Create an array of all the categories that are attached to posts.
-			$all_the_cool_cats = get_categories( array(
-				'fields'     => 'ids',
-				'hide_empty' => 1,
-				// We only need to know if there is more than one category.
-				'number'     => 2,
-			) );
+			$all_the_cool_cats = get_categories(
+				array(
+					'fields'     => 'ids',
+					'hide_empty' => 1,
+					// We only need to know if there is more than one category.
+					'number'     => 2,
+				)
+			);
 			// Count the number of categories that are attached to the posts.
 			$all_the_cool_cats = count( $all_the_cool_cats );
 			set_transient( 'understrap_categories', $all_the_cool_cats );
@@ -111,13 +117,13 @@ if ( ! function_exists( 'understrap_categorized_blog' ) ) {
 	}
 }
 
-/**
- * Flush out the transients used in understrap_categorized_blog.
- */
 add_action( 'edit_category', 'understrap_category_transient_flusher' );
-add_action( 'save_post',     'understrap_category_transient_flusher' );
+add_action( 'save_post', 'understrap_category_transient_flusher' );
 
 if ( ! function_exists( 'understrap_category_transient_flusher' ) ) {
+	/**
+	 * Flush out the transients used in understrap_categorized_blog.
+	 */
 	function understrap_category_transient_flusher() {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 add_filter( 'dynamic_sidebar_params', 'understrap_widget_classes' );
 
 if ( ! function_exists( 'understrap_widget_classes' ) ) {
+
 	/**
 	 * Count number of visible widgets in a sidebar and add classes to widgets accordingly,
 	 * so widgets can be displayed one, two, three or four per row.
@@ -24,6 +25,8 @@ if ( ! function_exists( 'understrap_widget_classes' ) ) {
 	 * @global array $sidebars_widgets
 	 *
 	 * @param array $params {
+	 *     Parameters passed to a widget’s display callback.
+	 *
 	 *     @type array $args  {
 	 *         An array of widget display arguments.
 	 *
@@ -86,7 +89,7 @@ if ( ! function_exists( 'understrap_widget_classes' ) ) {
 		return $params;
 
 	}
-} // endif function_exists( 'understrap_widget_classes' ).
+} // End of if function_exists( 'understrap_widget_classes' ).
 
 add_action( 'widgets_init', 'understrap_widgets_init' );
 
@@ -168,4 +171,4 @@ if ( ! function_exists( 'understrap_widgets_init' ) ) {
 		);
 
 	}
-} // endif function_exists( 'understrap_widgets_init' ).
+} // End of function_exists( 'understrap_widgets_init' ).

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -26,18 +26,18 @@ if ( ! function_exists( 'understrap_woocommerce_support' ) ) {
 	}
 }
 
-/**
- * First unhook the WooCommerce wrappers
- */
+// First unhook the WooCommerce content wrappers.
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
 remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
 
-/**
- * Then hook in your own functions to display the wrappers your theme requires
- */
+// Then hook in your own functions to display the wrappers your theme requires.
 add_action( 'woocommerce_before_main_content', 'understrap_woocommerce_wrapper_start', 10 );
 add_action( 'woocommerce_after_main_content', 'understrap_woocommerce_wrapper_end', 10 );
+
 if ( ! function_exists( 'understrap_woocommerce_wrapper_start' ) ) {
+	/**
+	 * Display the theme specific start of the page wrapper.
+	 */
 	function understrap_woocommerce_wrapper_start() {
 		$container = get_theme_mod( 'understrap_container_type' );
 		echo '<div class="wrapper" id="woocommerce-wrapper">';
@@ -47,7 +47,11 @@ if ( ! function_exists( 'understrap_woocommerce_wrapper_start' ) ) {
 		echo '<main class="site-main" id="main">';
 	}
 }
+
 if ( ! function_exists( 'understrap_woocommerce_wrapper_end' ) ) {
+	/**
+	 * Display the theme specific end of the page wrapper.
+	 */
 	function understrap_woocommerce_wrapper_end() {
 		echo '</main><!-- #main -->';
 		get_template_part( 'global-templates/right-sidebar-check' );
@@ -57,18 +61,17 @@ if ( ! function_exists( 'understrap_woocommerce_wrapper_end' ) ) {
 	}
 }
 
-
-/**
- * Filter hook function monkey patching form classes
- * Author: Adriano Monecchi http://stackoverflow.com/a/36724593/307826
- *
- * @param string $args Form attributes.
- * @param string $key Not in use.
- * @param null   $value Not in use.
- *
- * @return mixed
- */
 if ( ! function_exists( 'understrap_wc_form_field_args' ) ) {
+	/**
+	 * Filter hook function monkey patching form classes
+	 * Author: Adriano Monecchi http://stackoverflow.com/a/36724593/307826
+	 *
+	 * @param string $args Form attributes.
+	 * @param string $key Not in use.
+	 * @param null   $value Not in use.
+	 *
+	 * @return mixed
+	 */
 	function understrap_wc_form_field_args( $args, $key, $value = null ) {
 		// Start field type switch case.
 		switch ( $args['type'] ) {
@@ -133,7 +136,7 @@ if ( ! function_exists( 'understrap_wc_form_field_args' ) ) {
 				$args['input_class'] = array( 'form-control', 'input-lg' );
 				$args['label_class'] = array( 'control-label' );
 				break;
-		} // end switch ($args).
+		} // End of switch ( $args ).
 		return $args;
 	}
 }

--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -10,14 +10,14 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-/**
- * Adds support for wp.com-specific theme functions.
- *
- * @global array $themecolors
- */
 add_action( 'after_setup_theme', 'understrap_wpcom_setup' );
 
 if ( ! function_exists( 'understrap_wpcom_setup' ) ) {
+	/**
+	 * Adds support for wp.com-specific theme functions.
+	 *
+	 * @global array $themecolors
+	 */
 	function understrap_wpcom_setup() {
 		global $themecolors;
 
@@ -37,13 +37,12 @@ if ( ! function_exists( 'understrap_wpcom_setup' ) ) {
 	}
 }
 
-
-/*
- * WordPress.com-specific styles
- */
 add_action( 'wp_enqueue_scripts', 'understrap_wpcom_styles' );
 
 if ( ! function_exists( 'understrap_wpcom_styles' ) ) {
+	/**
+	 * WordPress.com-specific styles
+	 */
 	function understrap_wpcom_styles() {
 		wp_enqueue_style( 'understrap-wpcom', get_template_directory_uri() . '/inc/style-wpcom.css', array(), '20160411' );
 	}

--- a/index.php
+++ b/index.php
@@ -34,13 +34,11 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<main class="site-main" id="main">
 
-				<?php if ( have_posts() ) : ?>
-
-					<?php /* Start the Loop */ ?>
-
-					<?php while ( have_posts() ) : the_post(); ?>
-
-						<?php
+				<?php
+				if ( have_posts() ) {
+					// Start the Loop.
+					while ( have_posts() ) {
+						the_post();
 
 						/*
 						 * Include the Post-Format-specific template for the content.
@@ -48,15 +46,11 @@ $container = get_theme_mod( 'understrap_container_type' );
 						 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 						 */
 						get_template_part( 'loop-templates/content', get_post_format() );
-						?>
-
-					<?php endwhile; ?>
-
-				<?php else : ?>
-
-					<?php get_template_part( 'loop-templates/content', 'none' ); ?>
-
-				<?php endif; ?>
+					}
+				} else {
+					get_template_part( 'loop-templates/content', 'none' );
+				}
+				?>
 
 			</main><!-- #main -->
 
@@ -72,4 +66,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #index-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/loop-templates/content-none.php
+++ b/loop-templates/content-none.php
@@ -26,7 +26,7 @@ defined( 'ABSPATH' ) || exit;
 
 			$kses = array( 'a' => array( 'href' => array() ) );
 			printf(
-				/* translators: URL to create a new post. */
+				/* translators: 1: Link to WP admin new post page. */
 				'<p>' . wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'understrap' ), $kses ) . '</p>',
 				esc_url( admin_url( 'post-new.php' ) )
 			);

--- a/loop-templates/content-none.php
+++ b/loop-templates/content-none.php
@@ -22,25 +22,33 @@ defined( 'ABSPATH' ) || exit;
 	<div class="page-content">
 
 		<?php
-		if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
+		if ( is_home() && current_user_can( 'publish_posts' ) ) :
 
-			<p><?php printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'understrap' ), array(
-	'a' => array(
-		'href' => array(),
-	),
-) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			$kses = array( 'a' => array( 'href' => array() ) );
+			printf(
+				/* translators: URL to create a new post. */
+				'<p>' . wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'understrap' ), $kses ) . '</p>',
+				esc_url( admin_url( 'post-new.php' ) )
+			);
 
-		<?php elseif ( is_search() ) : ?>
+		elseif ( is_search() ) :
 
-			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'understrap' ); ?></p>
-			<?php
-				get_search_form();
-		else : ?>
+			printf(
+				'<p>%s<p>',
+				esc_html__( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'understrap' )
+			);
+			get_search_form();
 
-			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'understrap' ); ?></p>
-			<?php
-				get_search_form();
-		endif; ?>
+		else :
+
+			printf(
+				'<p>%s<p>',
+				esc_html__( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'understrap' )
+			);
+			get_search_form();
+
+		endif;
+		?>
 	</div><!-- .page-content -->
 
 </section><!-- .no-results -->

--- a/loop-templates/content-search.php
+++ b/loop-templates/content-search.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 		);
 		?>
 
-		<?php if ( 'post' == get_post_type() ) : ?>
+		<?php if ( 'post' === get_post_type() ) : ?>
 
 			<div class="entry-meta">
 

--- a/loop-templates/content.php
+++ b/loop-templates/content.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 		);
 		?>
 
-		<?php if ( 'post' == get_post_type() ) : ?>
+		<?php if ( 'post' === get_post_type() ) : ?>
 
 			<div class="entry-meta">
 				<?php understrap_posted_on(); ?>

--- a/page-templates/blank.php
+++ b/page-templates/blank.php
@@ -20,11 +20,12 @@ defined( 'ABSPATH' ) || exit;
 	<?php wp_head(); ?>
 </head>
 <body>
-	<?php while ( have_posts() ) : the_post(); ?>
-
-		<?php get_template_part( 'loop-templates/content', 'blank' ); ?>
-
-	<?php endwhile; // end of the loop. ?>
-	<?php wp_footer(); ?>
+	<?php
+	while ( have_posts() ) {
+		the_post();
+		get_template_part( 'loop-templates/content', 'blank' );
+	}
+	wp_footer();
+	?>
 </body>
 </html>

--- a/page-templates/both-sidebarspage.php
+++ b/page-templates/both-sidebarspage.php
@@ -20,30 +20,33 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 		<div class="row">
 
-			<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
+			<?php
+			get_template_part( 'sidebar-templates/sidebar', 'left' );
 
-			<div
-				class="<?php
-					if ( is_active_sidebar( 'left-sidebar' ) xor is_active_sidebar( 'right-sidebar' ) ) : ?>col-md-8<?php
-					elseif ( is_active_sidebar( 'left-sidebar' ) && is_active_sidebar( 'right-sidebar' ) ) : ?>col-md-4<?php
-					else : ?>col-md-12<?php
-					endif; ?> content-area"
-				id="primary">
+			if ( is_active_sidebar( 'left-sidebar' ) xor is_active_sidebar( 'right-sidebar' ) ) {
+				$class = 'col-md-8';
+			} elseif ( is_active_sidebar( 'left-sidebar' ) && is_active_sidebar( 'right-sidebar' ) ) {
+				$class = 'col-md-4';
+			} else {
+				$class = 'col-md-12';
+			}
+			?>
+			<div class="<?php echo $class; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 
-					<?php while ( have_posts() ) : the_post(); ?>
+					<?php
+					while ( have_posts() ) {
+						the_post();
 
-						<?php get_template_part( 'loop-templates/content', 'page' ); ?>
+						get_template_part( 'loop-templates/content', 'page' );
 
-						<?php
 						// If comments are open or we have at least one comment, load up the comment template.
-						if ( comments_open() || get_comments_number() ) :
+						if ( comments_open() || get_comments_number() ) {
 							comments_template();
-						endif;
-						?>
-
-					<?php endwhile; // end of the loop. ?>
+						}
+					}
+					?>
 
 				</main><!-- #main -->
 
@@ -57,4 +60,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/page-templates/fullwidthpage.php
+++ b/page-templates/fullwidthpage.php
@@ -12,12 +12,11 @@ defined( 'ABSPATH' ) || exit;
 
 get_header();
 $container = get_theme_mod( 'understrap_container_type' );
+
+if ( is_front_page() ) {
+	get_template_part( 'global-templates/hero' );
+}
 ?>
-
-<?php if ( is_front_page() ) : ?>
-  <?php get_template_part( 'global-templates/hero' ); ?>
-<?php endif; ?>
-
 
 <div class="wrapper" id="full-width-page-wrapper">
 
@@ -29,18 +28,17 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 				<main class="site-main" id="main" role="main">
 
-					<?php while ( have_posts() ) : the_post(); ?>
+					<?php
+					while ( have_posts() ) {
+						the_post();
+						get_template_part( 'loop-templates/content', 'page' );
 
-						<?php get_template_part( 'loop-templates/content', 'page' ); ?>
-
-						<?php
 						// If comments are open or we have at least one comment, load up the comment template.
-						if ( comments_open() || get_comments_number() ) :
+						if ( comments_open() || get_comments_number() ) {
 							comments_template();
-						endif;
-						?>
-
-					<?php endwhile; // end of the loop. ?>
+						}
+					}
+					?>
 
 				</main><!-- #main -->
 
@@ -52,4 +50,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #full-width-page-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/page-templates/left-sidebarpage.php
+++ b/page-templates/left-sidebarpage.php
@@ -22,24 +22,22 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<?php get_template_part( 'sidebar-templates/sidebar', 'left' ); ?>
 
-			<div
-				class="<?php if ( is_active_sidebar( 'left-sidebar' ) ) : ?>col-md-8<?php else : ?>col-md-12<?php endif; ?> content-area"
-				id="primary">
+			<div class="<?php echo is_active_sidebar( 'right-sidebar' ) ? 'col-md-8' : 'col-md-12'; ?> content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 
-					<?php while ( have_posts() ) : the_post(); ?>
+					<?php
+					while ( have_posts() ) {
+						the_post();
 
-						<?php get_template_part( 'loop-templates/content', 'page' ); ?>
+						get_template_part( 'loop-templates/content', 'page' );
 
-						<?php
 						// If comments are open or we have at least one comment, load up the comment template.
-						if ( comments_open() || get_comments_number() ) :
+						if ( comments_open() || get_comments_number() ) {
 							comments_template();
-						endif;
-						?>
-
-					<?php endwhile; // end of the loop. ?>
+						}
+					}
+					?>
 
 				</main><!-- #main -->
 
@@ -51,4 +49,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/page-templates/right-sidebarpage.php
+++ b/page-templates/right-sidebarpage.php
@@ -20,24 +20,22 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 		<div class="row">
 
-			<div
-				class="<?php if ( is_active_sidebar( 'right-sidebar' ) ) : ?>col-md-8<?php else : ?>col-md-12<?php endif; ?> content-area"
-				id="primary">
+			<div class="<?php echo is_active_sidebar( 'right-sidebar' ) ? 'col-md-8' : 'col-md-12'; ?> content-area" id="primary">
 
 				<main class="site-main" id="main" role="main">
 
-					<?php while ( have_posts() ) : the_post(); ?>
+					<?php
+					while ( have_posts() ) {
+						the_post();
 
-						<?php get_template_part( 'loop-templates/content', 'page' ); ?>
+						get_template_part( 'loop-templates/content', 'page' );
 
-						<?php
 						// If comments are open or we have at least one comment, load up the comment template.
-						if ( comments_open() || get_comments_number() ) :
+						if ( comments_open() || get_comments_number() ) {
 							comments_template();
-						endif;
-						?>
-
-					<?php endwhile; // end of the loop. ?>
+						}
+					}
+					?>
 
 				</main><!-- #main -->
 
@@ -51,4 +49,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/page.php
+++ b/page.php
@@ -30,18 +30,17 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<main class="site-main" id="main">
 
-				<?php while ( have_posts() ) : the_post(); ?>
+				<?php
+				while ( have_posts() ) {
+					the_post();
+					get_template_part( 'loop-templates/content', 'page' );
 
-					<?php get_template_part( 'loop-templates/content', 'page' ); ?>
-
-					<?php
 					// If comments are open or we have at least one comment, load up the comment template.
-					if ( comments_open() || get_comments_number() ) :
+					if ( comments_open() || get_comments_number() ) {
 						comments_template();
-					endif;
-					?>
-
-				<?php endwhile; // end of the loop. ?>
+					}
+				}
+				?>
 
 			</main><!-- #main -->
 
@@ -54,4 +53,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #page-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0"?>
 <ruleset name="UnderStrap Coding Standards">
 
-	<!-- Set a description for this ruleset. -->
-	<description>A custom set of code standard rules for UnderStrap.</description>
+	<description>Apply WordPress Coding Standards to UnderStrap</description>
+
+	<!-- Only scan PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<arg name="cache"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
 
 	<!-- Show colors in console -->
 	<arg value="-colors"/>
@@ -13,44 +21,16 @@
 	<!-- Don't show warnings -->
 	<arg value="n"/>
 
-	<!-- Only check the PHP files -->
-	<arg name="extensions" value="php"/>
-
 	<!-- Scan these files -->
 	<file>.</file>
 
-	<!-- Ignore the vendor directory -->
-	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<!-- Directories and third party library exclusions. -->
+	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>/dist/*</exclude-pattern>
 
 	<!-- Use the WordPress Ruleset -->
-	<rule ref="WordPress">
-		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd"/>
-		<exclude name="WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed"/>
-		<exclude name="WordPress.Security.EscapeOutput.UnsafePrintingFunction"/>
-		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
-		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
-		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
-		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
-		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText"/>
-
-		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
-		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed"/>
-		<exclude name="Generic.WhiteSpace.ScopeIndent"/>
-
-		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
-
-		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
-		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
-		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
-		<exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace"/>
-		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found"/>
-		<exclude name="Squiz.PHP.EmbeddedPhp"/>
-	</rule>
+	<rule ref="WordPress"/>
 
 	<!--
 		Verify that the text_domain is set to the desired text-domain.
@@ -72,33 +52,41 @@
 		</properties>
 	</rule>
 
+	<!-- Assignments in while conditions are a valid method of looping over iterables. -->
+	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition">
+		<exclude-pattern>*</exclude-pattern>
+	</rule>
+
+	<!-- Exclude incorrectly named files that won't be renamed. -->
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>/inc/class-wp-bootstrap-navwalker\.php</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.Security.EscapeOutput">
+		<!-- Exclude functions which are escaped in inc/extras.php -->
+		<properties>
+			<property name="customAutoEscapedFunctions" type="array">
+				<element value="get_the_title"/>
+				<element value="get_the_archive_title"/>
+				<element value="get_the_archive_description"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- 
+		Exclude checking of line endings when reporting errors, but fix them
+		when running phpcbf.
+	-->
+	<rule ref="Generic.Files.LineEndings">
+		<exclude phpcs-only="true" name="Generic.Files.LineEndings"/>
+	</rule>
+
 	<!-- A closing tag is not permitted at the end of a PHP file -->
 	<rule ref="Zend.Files.ClosingTag"/>
 
 	<!-- Use the PHPCompatibility Ruleset -->
-	<config name="testVersion" value="5.2-99.0"/>
-	<rule ref="PHPCompatibility">
-		<!--
-			Whitelist PHP native classes, interfaces, functions and constants which
-			are back-filled by WP.
-
-			Based on:
-			* /wp-includes/compat.php
-			* /wp-includes/random_compat/random.php
-		-->
-		<exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
-		<exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
-
-		<exclude name="PHPCompatibility.PHP.NewConstants.json_pretty_printFound"/>
-		<exclude name="PHPCompatibility.PHP.NewConstants.php_version_idFound"/>
-
-		<exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
-		<exclude name="PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound"/>
-
-		<exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
+	<config name="testVersion" value="5.6-99.0"/>
+	<rule ref="PHPCompatibilityWP">
+		<include-pattern>*\.php$</include-pattern>
 	</rule>
-
 </ruleset>

--- a/search.php
+++ b/search.php
@@ -42,18 +42,18 @@ $container = get_theme_mod( 'understrap_container_type' );
 					</header><!-- .page-header -->
 
 					<?php /* Start the Loop */ ?>
-					<?php while ( have_posts() ) : the_post(); ?>
+					<?php
+					while ( have_posts() ) :
+						the_post();
 
-						<?php
-						/**
+						/*
 						 * Run the loop for the search to output the results.
 						 * If you want to overload this in a child theme then include a file
 						 * called content-search.php and that will be used instead.
 						 */
 						get_template_part( 'loop-templates/content', 'search' );
-						?>
-
-					<?php endwhile; ?>
+					endwhile;
+					?>
 
 				<?php else : ?>
 
@@ -75,4 +75,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #search-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/sidebar-templates/sidebar-footerfull.php
+++ b/sidebar-templates/sidebar-footerfull.php
@@ -30,4 +30,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 	</div><!-- #wrapper-footer-full -->
 
-<?php endif;
+	<?php
+endif;

--- a/sidebar-templates/sidebar-hero.php
+++ b/sidebar-templates/sidebar-hero.php
@@ -43,4 +43,5 @@ defined( 'ABSPATH' ) || exit;
 	jQuery( ".carousel-item" ).first().addClass( "active" );
 	</script>
 
-<?php endif;
+	<?php
+endif;

--- a/sidebar-templates/sidebar-herocanvas.php
+++ b/sidebar-templates/sidebar-herocanvas.php
@@ -1,18 +1,15 @@
 <?php
 /**
- * Sidebar - hero canvas setup
+ * Sidebar - The Hero Canvas Widget Area
  *
  * @package understrap
  */
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
-?>
 
-<?php if ( is_active_sidebar( 'herocanvas' ) ) : ?>
+if ( is_active_sidebar( 'herocanvas' ) ) {
 
-	<!-- ******************* The Hero Canvas Widget Area ******************* -->
+	dynamic_sidebar( 'herocanvas' );
 
-	<?php dynamic_sidebar( 'herocanvas' ); ?>
-
-<?php endif;
+}

--- a/sidebar-templates/sidebar-statichero.php
+++ b/sidebar-templates/sidebar-statichero.php
@@ -29,4 +29,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 	</div><!-- #wrapper-static-hero -->
 
-<?php endif;
+	<?php
+endif;

--- a/single.php
+++ b/single.php
@@ -23,20 +23,18 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 			<main class="site-main" id="main">
 
-				<?php while ( have_posts() ) : the_post(); ?>
+				<?php
+				while ( have_posts() ) {
+					the_post();
+					get_template_part( 'loop-templates/content', 'single' );
+					understrap_post_nav();
 
-					<?php get_template_part( 'loop-templates/content', 'single' ); ?>
-
-					<?php understrap_post_nav(); ?>
-
-					<?php
 					// If comments are open or we have at least one comment, load up the comment template.
-					if ( comments_open() || get_comments_number() ) :
+					if ( comments_open() || get_comments_number() ) {
 						comments_template();
-					endif;
-					?>
-
-				<?php endwhile; // end of the loop. ?>
+					}
+				}
+				?>
 
 			</main><!-- #main -->
 
@@ -49,4 +47,5 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 </div><!-- #single-wrapper -->
 
-<?php get_footer();
+<?php
+get_footer();

--- a/woocommerce/cart/cart-empty.php
+++ b/woocommerce/cart/cart-empty.php
@@ -22,10 +22,12 @@ defined( 'ABSPATH' ) || exit;
  */
 do_action( 'woocommerce_cart_is_empty' );
 
-if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
+if ( wc_get_page_id( 'shop' ) > 0 ) :
+	?>
 	<p class="return-to-shop">
 		<a class="btn btn-outline-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
 			<?php esc_html_e( 'Return to shop', 'understrap' ); ?>
 		</a>
 	</p>
-<?php endif;
+	<?php
+endif;

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -67,9 +67,9 @@ do_action( 'woocommerce_before_cart' ); ?>
 						$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
 
 						if ( ! $product_permalink ) {
-							echo $thumbnail; // PHPCS: XSS ok.
+							echo $thumbnail; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						} else {
-							printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $thumbnail ); // PHPCS: XSS ok.
+							printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $thumbnail ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						}
 						?>
 						</td>
@@ -85,7 +85,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 						do_action( 'woocommerce_after_cart_item_name', $cart_item, $cart_item_key );
 
 						// Meta data.
-						echo wc_get_formatted_cart_item_data( $cart_item ); // PHPCS: XSS ok.
+						echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 						// Backorder notification.
 						if ( $_product->backorders_require_notification() && $_product->is_on_backorder( $cart_item['quantity'] ) ) {
@@ -96,7 +96,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 						<td class="product-price" data-title="<?php esc_attr_e( 'Price', 'understrap' ); ?>">
 							<?php
-								echo apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key ); // PHPCS: XSS ok.
+								echo apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							?>
 						</td>
 
@@ -118,13 +118,13 @@ do_action( 'woocommerce_before_cart' ); ?>
 							);
 						}
 
-						echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item ); // PHPCS: XSS ok.
+						echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						?>
 						</td>
 
 						<td class="product-subtotal" data-title="<?php esc_attr_e( 'Subtotal', 'understrap' ); ?>">
 							<?php
-								echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // PHPCS: XSS ok.
+								echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							?>
 						</td>
 					</tr>
@@ -173,4 +173,5 @@ do_action( 'woocommerce_before_cart' ); ?>
 	?>
 </div>
 
-<?php do_action( 'woocommerce_after_cart' ); ?>
+<?php
+do_action( 'woocommerce_after_cart' );

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -93,4 +93,5 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_mini_cart' ); ?>
+<?php
+do_action( 'woocommerce_after_mini_cart' );

--- a/woocommerce/cart/proceed-to-checkout-button.php
+++ b/woocommerce/cart/proceed-to-checkout-button.php
@@ -22,6 +22,6 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 
-<a href="<?php echo esc_url( wc_get_checkout_url() );?>" class="btn btn-primary btn-lg btn-block">
+<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="btn btn-primary btn-lg btn-block">
 	<?php esc_html_e( 'Proceed to checkout', 'understrap' ); ?>
 </a>

--- a/woocommerce/checkout/form-checkout.php
+++ b/woocommerce/checkout/form-checkout.php
@@ -61,4 +61,5 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 </form>
 
-<?php do_action( 'woocommerce_after_checkout_form', $checkout );
+<?php
+do_action( 'woocommerce_after_checkout_form', $checkout );

--- a/woocommerce/checkout/form-pay.php
+++ b/woocommerce/checkout/form-pay.php
@@ -17,7 +17,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$totals = $order->get_order_item_totals();
+$item_totals = $order->get_order_item_totals();
 ?>
 <form id="order_review" method="post">
 
@@ -56,8 +56,8 @@ $totals = $order->get_order_item_totals();
 			<?php endif; ?>
 		</tbody>
 		<tfoot>
-			<?php if ( $totals ) : ?>
-				<?php foreach ( $totals as $total ) : ?>
+			<?php if ( $item_totals ) : ?>
+				<?php foreach ( $item_totals as $total ) : ?>
 					<tr>
 						<th scope="row" colspan="2"><?php echo $total['label']; ?></th><?php // @codingStandardsIgnoreLine ?>
 						<td class="product-total"><?php echo $total['value']; ?></td><?php // @codingStandardsIgnoreLine ?>

--- a/woocommerce/global/form-login.php
+++ b/woocommerce/global/form-login.php
@@ -10,10 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates
-
- * @version     3.6.1
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.6.1
  */
 
 // Exit if accessed directly.
@@ -47,7 +46,7 @@ if ( is_user_logged_in() ) {
 			<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'understrap' ); ?></span>
 		</label>
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ) ?>" />
+		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ); ?>" />
 		<button type="submit" class="btn btn-outline-primary" name="login" value="<?php esc_attr_e( 'Login', 'understrap' ); ?>"><?php esc_html_e( 'Login', 'understrap' ); ?></button>
 
 	</p>

--- a/woocommerce/loop/add-to-cart.php
+++ b/woocommerce/loop/add-to-cart.php
@@ -10,10 +10,10 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     3.6.1
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 3.6.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,14 +22,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $product;
 
-echo apply_filters( 'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
-	sprintf( '<div class="add-to-cart-container"><a href="%s" data-quantity="%s" class="%s product_type_%s single_add_to_cart_button btn btn-outline-primary btn-block %s" %s> %s</a></div>',
+echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	'woocommerce_loop_add_to_cart_link',
+	sprintf(
+		'<div class="add-to-cart-container"><a href="%s" data-quantity="%s" class="%s product_type_%s single_add_to_cart_button btn btn-outline-primary btn-block %s" %s> %s</a></div>',
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( isset( $args['quantity'] ) ? $args['quantity'] : 1 ),
 		$product->is_purchasable() && $product->is_in_stock() ? 'add_to_cart_button' : '',
 		esc_attr( $product->get_type() ),
-		$product->get_type() == 'simple' ? 'ajax_add_to_cart' : '',
+		$product->get_type() === 'simple' ? 'ajax_add_to_cart' : '',
 		isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
 		esc_html( $product->add_to_cart_text() )
 	),
-$product, $args );
+	$product,
+	$args
+);

--- a/woocommerce/loop/orderby.php
+++ b/woocommerce/loop/orderby.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates
- * @version     3.6.1
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.6.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,8 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <form class="woocommerce-ordering" method="get">
 	<select name="orderby" class="orderby custom-select" aria-label="<?php esc_attr_e( 'Shop order', 'understrap' ); ?>">
-		<?php foreach ( $catalog_orderby_options as $id => $name ) : ?>
-			<option value="<?php echo esc_attr( $id ); ?>" <?php selected( $orderby, $id ); ?>><?php echo esc_html( $name ); ?></option>
+		<?php foreach ( $catalog_orderby_options as $option_id => $name ) : ?>
+			<option value="<?php echo esc_attr( $option_id ); ?>" <?php selected( $orderby, $option_id ); ?>><?php echo esc_html( $name ); ?></option>
 		<?php endforeach; ?>
 	</select>
 	<input type="hidden" name="paged" value="1" />

--- a/woocommerce/myaccount/downloads.php
+++ b/woocommerce/myaccount/downloads.php
@@ -12,7 +12,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates
  * @version 3.6.1
@@ -38,10 +38,11 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 <?php else : ?>
 	<div class="woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="btn btn-outline-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go shop', 'understrap' ) ?>
+			<?php esc_html_e( 'Go shop', 'understrap' ); ?>
 		</a>
 		<?php esc_html_e( 'No downloads available yet.', 'understrap' ); ?>
 	</div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_account_downloads', $has_downloads );
+<?php
+do_action( 'woocommerce_after_account_downloads', $has_downloads );

--- a/woocommerce/myaccount/form-edit-account.php
+++ b/woocommerce/myaccount/form-edit-account.php
@@ -73,4 +73,5 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 	<?php do_action( 'woocommerce_edit_account_form_end' ); ?>
 </form>
 
-<?php do_action( 'woocommerce_after_edit_account_form' );
+<?php
+do_action( 'woocommerce_after_edit_account_form' );

--- a/woocommerce/myaccount/form-edit-address.php
+++ b/woocommerce/myaccount/form-edit-address.php
@@ -53,4 +53,5 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_edit_account_address_form' );
+<?php
+do_action( 'woocommerce_after_edit_account_address_form' );

--- a/woocommerce/myaccount/form-login.php
+++ b/woocommerce/myaccount/form-login.php
@@ -117,4 +117,5 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 </div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_customer_login_form' );
+<?php
+do_action( 'woocommerce_after_customer_login_form' );

--- a/woocommerce/myaccount/my-address.php
+++ b/woocommerce/myaccount/my-address.php
@@ -17,20 +17,28 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 $customer_id = get_current_user_id();
 
 if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) {
-	$get_addresses = apply_filters( 'woocommerce_my_account_get_addresses', array(
-		'billing' => __( 'Billing address', 'understrap' ),
-		'shipping' => __( 'Shipping address', 'understrap' ),
-	), $customer_id );
+	$get_addresses = apply_filters(
+		'woocommerce_my_account_get_addresses',
+		array(
+			'billing'  => __( 'Billing address', 'understrap' ),
+			'shipping' => __( 'Shipping address', 'understrap' ),
+		),
+		$customer_id
+	);
 } else {
-	$get_addresses = apply_filters( 'woocommerce_my_account_get_addresses', array(
-		'billing' => __( 'Billing address', 'understrap' ),
-	), $customer_id );
+	$get_addresses = apply_filters(
+		'woocommerce_my_account_get_addresses',
+		array(
+			'billing' => __( 'Billing address', 'understrap' ),
+		),
+		$customer_id
+	);
 }
 
 $oldcol = 1;
@@ -38,28 +46,31 @@ $col    = 1;
 ?>
 
 <p>
-	<?php echo apply_filters( 'woocommerce_my_account_my_address_description', __( 'The following addresses will be used on the checkout page by default.', 'understrap' ) ); ?>
+	<?php echo apply_filters( 'woocommerce_my_account_my_address_description', esc_html__( 'The following addresses will be used on the checkout page by default.', 'understrap' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 </p>
 
 <?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) : ?>
 	<div class="u-columns woocommerce-Addresses col2-set addresses">
 <?php endif; ?>
 
-<?php foreach ( $get_addresses as $name => $title ) : ?>
+<?php foreach ( $get_addresses as $name => $address_title ) : ?>
 
 	<div class="u-column woocommerce-Address">
 		<header class="woocommerce-Address-title title">
-			<h3><?php echo $title; ?></h3>
-			<a href="<?php echo esc_url( wc_get_endpoint_url( 'edit-address', $name ) ); ?>" class="edit"><?php _e( 'Edit', 'understrap' ); ?></a>
+			<h3><?php echo esc_html( $address_title ); ?></h3>
+			<a href="<?php echo esc_url( wc_get_endpoint_url( 'edit-address', $name ) ); ?>" class="edit"><?php esc_html_e( 'Edit', 'understrap' ); ?></a>
 		</header>
-		<address><?php
+		<address>
+		<?php
 			$address = wc_get_account_formatted_address( $name );
 			echo $address ? wp_kses_post( $address ) : esc_html_e( 'You have not set up this type of address yet.', 'understrap' );
-		?></address>
+		?>
+		</address>
 	</div>
 
 <?php endforeach; ?>
 
 <?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) : ?>
 	</div>
-<?php endif;
+	<?php
+endif;

--- a/woocommerce/myaccount/my-orders.php
+++ b/woocommerce/myaccount/my-orders.php
@@ -2,6 +2,7 @@
 /**
  * My Orders - Deprecated
  *
+ * @package WooCommerce/Templates
  * @deprecated 2.6.0 this template file is no longer used. My Account shortcode uses orders.php.
  */
 
@@ -9,25 +10,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$my_orders_columns = apply_filters( 'woocommerce_my_account_my_orders_columns', array(
-	'order-number'  => __( 'Order', 'understrap' ),
-	'order-date'    => __( 'Date', 'understrap' ),
-	'order-status'  => __( 'Status', 'understrap' ),
-	'order-total'   => __( 'Total', 'understrap' ),
-	'order-actions' => '&nbsp;',
-) );
+$my_orders_columns = apply_filters(
+	'woocommerce_my_account_my_orders_columns',
+	array(
+		'order-number'  => esc_html__( 'Order', 'understrap' ),
+		'order-date'    => esc_html__( 'Date', 'understrap' ),
+		'order-status'  => esc_html__( 'Status', 'understrap' ),
+		'order-total'   => esc_html__( 'Total', 'understrap' ),
+		'order-actions' => '&nbsp;',
+	)
+);
 
-$customer_orders = get_posts( apply_filters( 'woocommerce_my_account_my_orders_query', array(
-	'numberposts' => $order_count,
-	'meta_key'    => '_customer_user',
-	'meta_value'  => get_current_user_id(),
-	'post_type'   => wc_get_order_types( 'view-orders' ),
-	'post_status' => array_keys( wc_get_order_statuses() ),
-) ) );
+$customer_orders = get_posts(
+	apply_filters(
+		'woocommerce_my_account_my_orders_query',
+		array(
+			'numberposts' => $order_count,
+			'meta_key'    => '_customer_user', // phpcs:ignore WordPress.DB.SlowDBQuery
+			'meta_value'  => get_current_user_id(), // phpcs:ignore WordPress.DB.SlowDBQuery
+			'post_type'   => wc_get_order_types( 'view-orders' ),
+			'post_status' => array_keys( wc_get_order_statuses() ),
+		)
+	)
+);
 
 if ( $customer_orders ) : ?>
 
-	<h2><?php echo apply_filters( 'woocommerce_my_account_my_orders_title', __( 'Recent orders', 'understrap' ) ); ?></h2>
+	<h2><?php echo apply_filters( 'woocommerce_my_account_my_orders_title', esc_html__( 'Recent orders', 'understrap' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h2>
 
 	<table class="shop_table shop_table_responsive my_account_orders table-hover table-striped">
 
@@ -40,8 +49,9 @@ if ( $customer_orders ) : ?>
 		</thead>
 
 		<tbody>
-			<?php foreach ( $customer_orders as $customer_order ) :
-				$order      = wc_get_order( $customer_order );
+			<?php
+			foreach ( $customer_orders as $customer_order ) :
+				$order      = wc_get_order( $customer_order ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Override
 				$item_count = $order->get_item_count();
 				?>
 				<tr class="order">
@@ -52,7 +62,7 @@ if ( $customer_orders ) : ?>
 
 							<?php elseif ( 'order-number' === $column_id ) : ?>
 								<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>">
-									<?php echo _x( '#', 'hash before order number', 'understrap' ) . $order->get_order_number(); ?>
+									<?php echo _x( '#', 'hash before order number', 'understrap' ) . $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 								</a>
 
 							<?php elseif ( 'order-date' === $column_id ) : ?>
@@ -64,16 +74,16 @@ if ( $customer_orders ) : ?>
 							<?php elseif ( 'order-total' === $column_id ) : ?>
 								<?php
 								/* translators: 1: formatted order total 2: total order items */
-								printf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'understrap' ), $order->get_formatted_order_total(), $item_count );
+								printf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'understrap' ), $order->get_formatted_order_total(), $item_count ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 								?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
 								<?php
-								$actions = wc_get_account_orders_actions( $order );
+								$orders_actions = wc_get_account_orders_actions( $order );
 
-								if ( ! empty( $actions ) ) {
-									foreach ( $actions as $key => $action ) {
-										echo '<a href="' . esc_url( $action['url'] ) . '" class="btn btn-outline-primary ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
+								if ( ! empty( $orders_actions ) ) {
+									foreach ( $orders_actions as $key => $orders_action ) {
+										echo '<a href="' . esc_url( $orders_action['url'] ) . '" class="btn btn-outline-primary ' . sanitize_html_class( $key ) . '">' . esc_html( $orders_action['name'] ) . '</a>';
 									}
 								}
 								?>
@@ -84,4 +94,5 @@ if ( $customer_orders ) : ?>
 			<?php endforeach; ?>
 		</tbody>
 	</table>
-<?php endif;
+	<?php
+endif;

--- a/woocommerce/myaccount/navigation.php
+++ b/woocommerce/myaccount/navigation.php
@@ -27,9 +27,10 @@ do_action( 'woocommerce_before_account_navigation' );
 	<div class="list-group">
 			<?php foreach ( wc_get_account_menu_items() as $endpoint => $label ) : ?>
 				<a href="<?php echo esc_url( wc_get_account_endpoint_url( $endpoint ) ); ?>"
-				   class="list-group-item list-group-item-action"><?php echo esc_html( $label ); ?></a>
+					class="list-group-item list-group-item-action"><?php echo esc_html( $label ); ?></a>
 			<?php endforeach; ?>
 	</div>
 </nav>
 
-<?php do_action( 'woocommerce_after_account_navigation' );
+<?php
+do_action( 'woocommerce_after_account_navigation' );

--- a/woocommerce/myaccount/orders.php
+++ b/woocommerce/myaccount/orders.php
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 		<tbody>
 			<?php
 			foreach ( $customer_orders->orders as $customer_order ) {
-				$order      = wc_get_order( $customer_order ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+				$order      = wc_get_order( $customer_order ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Override
 				$item_count = $order->get_item_count() - $order->get_item_count_refunded();
 				?>
 				<tr class="woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $order->get_status() ); ?> order">
@@ -63,11 +63,11 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
 								<?php
-								$actions = wc_get_account_orders_actions( $order );
+								$orders_actions = wc_get_account_orders_actions( $order );
 
-								if ( ! empty( $actions ) ) {
-									foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button btn btn-outline-primary ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
+								if ( ! empty( $orders_actions ) ) {
+									foreach ( $orders_actions as $key => $orders_action ) {
+										echo '<a href="' . esc_url( $orders_action['url'] ) . '" class="woocommerce-button btn btn-outline-primary ' . sanitize_html_class( $key ) . '">' . esc_html( $orders_action['name'] ) . '</a>';
 									}
 								}
 								?>
@@ -104,4 +104,5 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 	</div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_account_orders', $has_orders ); ?>
+<?php
+do_action( 'woocommerce_after_account_orders', $has_orders );

--- a/woocommerce/single-product/add-to-cart/simple.php
+++ b/woocommerce/single-product/add-to-cart/simple.php
@@ -23,7 +23,7 @@ if ( ! $product->is_purchasable() ) {
 	return;
 }
 
-echo wc_get_stock_html( $product ); // WPCS: XSS ok.
+echo wc_get_stock_html( $product ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 if ( $product->is_in_stock() ) : ?>
 
@@ -35,11 +35,13 @@ if ( $product->is_in_stock() ) : ?>
 		<?php
 		do_action( 'woocommerce_before_add_to_cart_quantity' );
 
-		woocommerce_quantity_input( array(
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
-			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // WPCS: CSRF ok, input var ok.
-		) );
+		woocommerce_quantity_input(
+			array(
+				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
+				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+				'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			)
+		);
 
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
@@ -51,4 +53,5 @@ if ( $product->is_in_stock() ) : ?>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_form' ); ?>
 
-<?php endif;
+	<?php
+endif;

--- a/woocommerce/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/woocommerce/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -17,11 +17,13 @@ global $product;
 	<?php
 	do_action( 'woocommerce_before_add_to_cart_quantity' );
 
-	woocommerce_quantity_input( array(
-		'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-		'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
-		'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // WPCS: CSRF ok, input var ok.
-	) );
+	woocommerce_quantity_input(
+		array(
+			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
+			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		)
+	);
 
 	do_action( 'woocommerce_after_add_to_cart_quantity' );
 	?>


### PR DESCRIPTION
- Fixes many WPCS errors and warnings
- Adds functions for escaping titles and archive descriptions
  - Adds `understrap_kses_title()` to escape post titles.
  - Adds `understrap_escape_the_archive_description()` to escape the archive description.

Also:
* Partly removes excessive php opening/closing tags.
* Uses printf in `loop-templates/content-none.php`.
* Fixes missing '__' after `esc_html` in author.php.
* Updates the `phpcs.xml` to reflect all the changes.
* Updates composer dependencies and scripts.
* Removes the content-none template from the `<ul>`in `author.php`

(Incorporates changes proposed in #1013 and #1016)