### PR TITLE
Remove some relics from gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -306,13 +306,6 @@ gulp.task(
 			)
 			.pipe(
 				replace(
-					'/js/jquery.slim.min.js',
-					'/js' + paths.vendor + '/jquery.slim.min.js',
-					{ skipBinary: true }
-				)
-			)
-			.pipe(
-				replace(
 					'/js/popper.min.js',
 					'/js' + paths.vendor + '/popper.min.js',
 					{

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -261,8 +261,6 @@ gulp.task( 'clean-vendor-assets', function() {
 		paths.dev + '/sass/underscores',
 		paths.dev + '/js/skip-link-focus-fix.js',
 		paths.js + '/**/skip-link-focus-fix.js',
-		paths.js + '/**/popper.min.js',
-		paths.js + '/**/popper.js',
 		paths.js + paths.vendor,
 	] );
 } );
@@ -303,15 +301,6 @@ gulp.task(
 					'!CHANGELOG.md',
 				],
 				{ buffer: true }
-			)
-			.pipe(
-				replace(
-					'/js/popper.min.js',
-					'/js' + paths.vendor + '/popper.min.js',
-					{
-						skipBinary: true,
-					}
-				)
 			)
 			.pipe(
 				replace(


### PR DESCRIPTION
`jquery.slim.min.js` has been removed in v0.6.9.3.
`popper.js` and `popper.min.js` have been removed in v0.8.8.