### PR TITLE
Remove gulp-touch-fd

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@ var plumber = require( 'gulp-plumber' );
 var sass = require( 'gulp-sass' );
 var babel = require( 'gulp-babel' );
 var postcss = require( 'gulp-postcss' );
-var touch = require( 'gulp-touch-fd' );
 var rename = require( 'gulp-rename' );
 var concat = require( 'gulp-concat' );
 var uglify = require( 'gulp-uglify' );
@@ -26,7 +25,7 @@ var paths = cfg.paths;
  * Run: gulp sass
  */
 gulp.task( 'sass', function() {
-	var stream = gulp
+	return gulp
 		.src( paths.sass + '/*.scss' )
 		.pipe(
 			plumber( {
@@ -40,9 +39,7 @@ gulp.task( 'sass', function() {
 		.pipe( sass( { errLogToConsole: true } ) )
 		.pipe( postcss( [ autoprefixer() ] ) )
 		.pipe( sourcemaps.write( undefined, { sourceRoot: null } ) )
-		.pipe( gulp.dest( paths.css ) )
-		.pipe( touch() );
-	return stream;
+		.pipe( gulp.dest( paths.css ) );
 } );
 
 /**
@@ -107,8 +104,7 @@ gulp.task( 'minifycss', function() {
 		)
 		.pipe( rename( { suffix: '.min' } ) )
 		.pipe( sourcemaps.write( './' ) )
-		.pipe( gulp.dest( paths.css ) )
-		.pipe( touch() );
+		.pipe( gulp.dest( paths.css ) );
 } );
 
 /**
@@ -304,8 +300,7 @@ gulp.task(
 					{ skipBinary: true }
 				)
 			)
-			.pipe( gulp.dest( paths.dist ) )
-			.pipe( touch() );
+			.pipe( gulp.dest( paths.dist ) );
 	} )
 );
 
@@ -336,8 +331,7 @@ gulp.task(
 				'!' + paths.distprod,
 				'!' + paths.distprod + '/**',
 			] )
-			.pipe( gulp.dest( paths.distprod ) )
-			.pipe( touch() );
+			.pipe( gulp.dest( paths.distprod ) );
 	} )
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5312,15 +5312,6 @@
         }
       }
     },
-    "gulp-touch-fd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-touch-fd/-/gulp-touch-fd-2.0.0.tgz",
-      "integrity": "sha512-rXhmJaWGylYoVJJ7tL2enb4jJBfzSU5rLnuaTj9TUaYf1HwRYmLlSJRPUvFB/8rH5YzxdZ2K0sSWB56bZt3jfA==",
-      "dev": true,
-      "requires": {
-        "map-stream": "0.0.7"
-      }
-    },
     "gulp-uglify": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
@@ -6555,12 +6546,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
     },
     "map-visit": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "gulp-replace": "^1.0.0",
     "gulp-sass": "^4.1.0",
     "gulp-sourcemaps": "^2.6.5",
-    "gulp-touch-fd": "^2.0.0",
     "gulp-uglify": "^3.0.2"
   }
 }


### PR DESCRIPTION
No need for gulp-touch-fd (anymore) which was added in #1040 by @lilumi.
- gulp.dest [updates metadata](https://gulpjs.com/docs/en/api/dest/#metadata-updates).
- From v4.1.0 gulp-sass updates the modified time (https://github.com/dlmanning/gulp-sass/releases/tag/v4.1.0).

@UnderstrapFramework please merge