### PR TITLE
Re-add PHPCS config file to ignored files in dist task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -288,7 +288,7 @@ gulp.task(
 					'!' + paths.composer,
 					'!' + paths.composer + '/**',
 					'!+(readme|README).+(txt|md)',
-					'!*.+(json|js|lock|xml)',
+					'!*.+(dist|json|js|lock|xml)',
 					'!CHANGELOG.md',
 				],
 				{ buffer: true }


### PR DESCRIPTION
The PHPCS config file has been renamed from phpcs.xml to phpcs.xml.dist in #1165 without adjusting the list of file extensions which are ignored in the dist task. This PR adds .dist to that list of file extensions.

@UnderstrapFramework please merge