### PR TITLE
Remove port from Browsersync's proxy option

### DIFF
--- a/gulpconfig.json
+++ b/gulpconfig.json
@@ -1,6 +1,6 @@
 {
 	"browserSyncOptions": {
-		"proxy": "localhost:8080/",
+		"proxy": "localhost/",
 		"notify": false,
 		"files": ["./css/*.min.css", "./js/*.min.js", "./**/*.php"]
 	},


### PR DESCRIPTION
## Description
Removes port from Browsersync's proxy option in gulpconfig.json.
```diff
"browserSyncOptions": {
-	"proxy": "localhost:8080/",
+	"proxy": "localhost/",
	"notify": false,
	"files": ["./css/*.min.css", "./js/*.min.js", "./**/*.php"]
},
```

## Motivation and Context
Port 8080 has been added in #955. Explicitly providing a port prevents Browsersync to auto-detect the port and misguides users (see #1198).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] `composer cs:check` has passed locally.
- [ ] `composer lint:php` has passed locally.
- [x] I have read the **CONTRIBUTING** document.
