### PR TITLE
Fix styling of WooCommerce product search widget

### DIFF
--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -11,9 +11,8 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -23,11 +22,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <form role="search" method="get" class="woocommerce-product-search" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<div class="input-group">
+		<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field form-control" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'understrap' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />	
 		<label class="sr-only" for="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'understrap' ); ?></label>
-		<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field field form-control" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'understrap' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
 		<input type="hidden" name="post_type" value="product" />
-		<span class="input-group-append">
-			<button class="submit btn btn-primary" type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'understrap' ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'understrap' ); ?></button>
-		</span>
+		<div class="input-group-append">
+			<button class="btn btn-primary" type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'understrap' ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'understrap' ); ?></button>
+	</div>
 	</div>
 </form>


### PR DESCRIPTION
## Description
Fixes the order of elements inside the input group.

Before fix:
![image](https://user-images.githubusercontent.com/42134098/85212874-69fdf880-b357-11ea-86da-f594e773d249.png)
After fix:
![image](https://user-images.githubusercontent.com/42134098/85212886-813ce600-b357-11ea-9c86-1dc7d7ddafd1.png)

## Motivation and Context
Because of the wrong order of elements inside the input group Bootstrap styles weren't applied correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **CONTRIBUTING** document.