### PR TITLE
Update woocommerce.scss to fix coupon field size

### DIFF
--- a/sass/understrap/woocommerce.scss
+++ b/sass/understrap/woocommerce.scss
@@ -8,9 +8,9 @@ figure.woocommerce-product-gallery__wrapper {
 	max-width: inherit !important;
 }
 
-// Fix coupon code input width
+// Fix coupon code input width for cart, apply only to the cart as it will break the checkout field width
 @media(min-width: 768px) {
-	#coupon_code.input-text {
+	.woocommerce-cart #coupon_code.input-text {
 		width: 110px !important;
 	}
 }


### PR DESCRIPTION
Fix coupon code input width, apply only to the cart as it will break the checkout field width

<!--- Provide a general summary of your changes in the Title above -->

## Description
Change CSS rule to only include the cart page.

## Motivation and Context
Fixes issue with checkout coupon field size.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [ ] I have read the **CONTRIBUTING** document.
