### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files that will always be normalized and converted
+# to native line endings on checkout.
+.browserslistrc text
+.editorconfig   text
+.gitattributes  text
+.gitignore      text
+.jscsrc         text
+.jshintignore   text
+*.css           text
+*.js            text
+*.json          text
+*.map           text -diff
+*.md            text
+*.txt           text
+*.xml           text
+*.yml           text
+
+# Declare files that will always have LF line endings on checkout.
+*.php text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.jpg binary
+*.png binary

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # but track
 !.browserslist
 !.editorconfig
+!.gitattributes
 !.gitignore
 !.jscsrc
 !.jshintignore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Declares PHP files to always have LF line endings on checkout. Useful for users on Windows.

## Motivation and Context
At least Github Desktop keeps changing line ending from LF to CRLF on checkout.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [ ] `composer lint:php` has passed locally.
- [x] I have read the **CONTRIBUTING** document.

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
@UnderstrapFramework  please merge