### PR TITLE
docs: change $classes type to array in understrap_adjust_body_class()

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
 	/**
 	 * Setup body classes.
 	 *
-	 * @param string $classes CSS classes.
+	 * @param array $classes CSS classes.
 	 *
 	 * @deprecated 0.9.4 Styling of tag has been removed in Bootstrap v4 Alpha 6.
 	 * @link https://github.com/twbs/bootstrap/issues/20939


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected the PHPDoc for this function to give `$classes` a type of `array`, instead of `string`.

## Motivation and Context
Per docs at https://developer.wordpress.org/reference/hooks/body_class/, the body_class hook provides $classes as an array, not a string. Intelephense also complains that a string is not iterable with foreach - this correction fixes that.

The function is currently in deprecated.php, but it's still good to correct it, in case it comes back, and to avoid linter issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **CONTRIBUTING** document.

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
