### PR TITLE
Add oldest PHP version supported

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@ That downloads everything and moves it in place so that you can recompile your C
 A developer version (with Gulp/node and Sass sources) is available on gitHub: https://github.com/understrap/understrap
 A child theme is available on Github, too: https://github.com/understrap/understrap-child;
 Version: 0.9.4
+Requires PHP: 5.2
 License: UnderStrap WordPress Theme, Copyright 2013-2017 Holger Koenemann
 UnderStrap is distributed under the terms of the GNU GPL version 2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the oldest PHP version supported to the header comment section of the `style.css`.
PHPCompatibilityWP checks for PHP 5.2+ pass. See: `composer cs:check`. cs:check includes the WPThemeReview ruleset which uses PHPCompatibilityWP to check for compatibility with PHP 5.2 and higher.

## Motivation and Context
See issue #1183

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
@UnderstrapFramework please merge