### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Set up for npm and Composer
+
+version: 2
+updates:
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    versioning-strategy: increase
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    allow:
+    - dependency-type: direct
+    - dependency-type: indirect
+    directory: "/"
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    versioning-strategy: increase


### PR DESCRIPTION
## Description
This pull request migrates the Dependabot configuration from Dependabot.com to a config file, using the [new syntax](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates). When merged, `dependabot-preview` will be swap out for a new `dependabot` app!

## Motivation and Context
Dependabot Preview will be shut down on August 3rd, 2021. In order to keep getting Dependabot updates, one has to migrate to GitHub-native Dependabot before then.

After that date, any open pull requests from Dependabot Preview will remain open, but the bot itself will no longer work on your GitHub accounts and organizations.
