### PR TITLE
Updates to WooCommerce Templates and language POT file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,40 @@
+## [Unreleased]
+
+** Enhancements **
+
+  - Introduces [Unreleased] Section at top of CHANGELOG.md to hold items until the branch is ready for release.
+
+** Fixes **
+
+  - Updates WooCommerce templates to current versions.
+  - Corrects mis-applied version numbers in WooCommerce templates.
+  - Reverts WooCommerce Translations to woocommerce language domain.
+  - Updates understrap.pot file to include several translation strings that had not been added.
+  - Fixes spelling and grammar errors in the CHANGELOG.md.
+
+
+
 ## Release 0.9.6 June 15th 2021
 This is a bugfix and maintenance release.
 
 ** Enhancements **
-
-- Set credit links to use https protocol.
+  - Set credit links to use https protocol.
 
 ** Fixes **
-
-- Use get_theme_file_path() to make include files child theme friendly.
-
-	- Fixes breaking child theme overloading /inc/ folder files.
+  - Use get_theme_file_path() to make include files child theme friendly.
+  - Fixes breaking child theme overloading /inc/ folder files.
 
 ** Dependency Updates **
-
-- Bump ws from 7.4.3 to 7.4.6
-- Bump browserslist from 4.16.1 to 4.16.6
-- Bump postcss from 8.2.9 to 8.2.10
-- Bump hosted-git-info from 2.8.8 to 2.8.9
-- Bump lodash from 4.17.20 to 4.17.21
-- Bump ua-parser-js from 0.7.23 to 0.7.28
+  - Bump ws from 7.4.3 to 7.4.6
+  - Bump browserslist from 4.16.1 to 4.16.6
+  - Bump postcss from 8.2.9 to 8.2.10
+  - Bump hosted-git-info from 2.8.8 to 2.8.9
+  - Bump lodash from 4.17.20 to 4.17.21
+  - Bump ua-parser-js from 0.7.23 to 0.7.28
 
 
 ## Release 0.9.5 June 10th 2021
-This is a maintenance release incorporating many commits including code formatting and dependency updates that have occured over the past two years. There are still many dependancy updates remaining and they will be addressed in new releases coming soon, but we want to get this release synced first.
+This is a maintenance release incorporating many commits including code formatting and dependency updates that have occurred over the past two years. There are still many dependency updates remaining, and they will be addressed in new releases coming soon, but we want to get this release synced first.
 
 ** Enhancements **
 - Re-add custom-javascript.js
@@ -69,11 +81,10 @@ e6c9552
 Commits on Feb 19, 2019
 Lon Koenig
 Lon Koenig
-Make understrap_mobile_web_app_meta() and understrap_pingback() plugg…
+Make understrap_mobile_web_app_meta() and understrap_pingback() plug…
 6fcf1e9
 
 Commits on Feb 22, 2019
-Noel Springer
 Noel Springer
 Update form-reset-password template for Woocommerce 3.5.5
 85ef63c
@@ -138,121 +149,95 @@ a4f20ac
 
 Commits on Apr 19, 2019
 Chris Bibby
-Chris Bibby
 initial
 89f2509
-Chris Bibby
 Chris Bibby
 Woocommerce 3.6.1 template changes
 1ab2f98
 Chris Bibby
-Chris Bibby
 Woocommerce 3.6.1 template changes
 d60c6d4
-Chris Bibby
 Chris Bibby
 woocommerce 3.6.1 template changes
 cb67c41
 Chris Bibby
-Chris Bibby
 woocommerce 3.6.1 template changes
 7d8e00f
 Chris Bibby
-Chris Bibby
 woocommerce 3.6.1 template changes
 a28c44d
-Chris Bibby
 Chris Bibby
 woocommerce 3.6.1 template changes
 c500160
 Commits on Apr 20, 2019
 Chris Bibby
-Chris Bibby
 Woocommerce 3.6.1 updates
 1fe315c
-Chris Bibby
 Chris Bibby
 Merge branch 'woocommerce-3.6.1-updates' of https://github.com/chrism…
 b8766a7
 
 Commits on Apr 22, 2019
 @holger1411
-holger1411
 Update Woocommerce version info
 cac4962
 
 Commits on Apr 28, 2019
 @holger1411
-holger1411
 Merge branch 'master' into woocommerce-3.6.1-updates
 c293c82
 @holger1411
-holger1411
 Merge pull request #955 from chrismb75/woocommerce-3.6.1-updates
 8af84c1
 @holger1411
-holger1411
 Fixing watch-bs task
 bbae68f
 
 Commits on Apr 29, 2019
 @IanDelMar
-IanDelMar
 WooCommerce backward compatibility. Fix for #961
 8b841fb
 
 Commits on Apr 30, 2019
 @kelsS
-kelsS
 removed bower.json since bower is no longer used
 7475ec1
 @kelsS
-kelsS
 add php to allow the hero widgets to show on the fullwidth page templ…
 2f5e018
 
 Commits on May 01, 2019
 @kelsS
-kelsS
 add babel, gulp-babel, autoprefixer, and gulp-postcss as dev dependen…
 0ea4793
 @kelsS
-kelsS
 add babel core, gulp-babel, autoprefixer, and gulp-postcss to gulp pr…
 b179eaf
 @IanDelMar
-IanDelMar
 Add support for wp_body_open
 0e76b40
 
 Commits on May 03, 2019
 @IanDelMar
-IanDelMar
 Improve code simplicity
 6076c91
 
 Commits on May 08, 2019
 @holger1411
-holger1411
 Merge pull request #967 from IanDelMar/wp_body_open
 1e90d3c
 @holger1411
-holger1411
 Merge pull request #965 from kelsS/master
 a09fcbe
 @holger1411
-holger1411
 Merge pull request #963 from IanDelMar/patch-6
 2d80cf4
 @holger1411
-holger1411
 Re-add customizer.js
 01af1b4
 @holger1411
-holger1411
 Clean rebuild
 5f9b8b2
-
 
 ## Release 0.9.1 February 15th, 2019 - SECURITY UPDATE
 - Update to Bootstrap 4.3.1 - Fixes a XSS vulnerability in BS 4.3.0
@@ -298,7 +283,6 @@ Clean rebuild
   - Remove $sidebar_pos - Thx @IanDelMar
   - Update Woocommerce templates for WC 3.5.x - thx @ Noel Springer
 
-
 ## Release 0.8.7 September 11th 2018
   - Spelling corrections thx @davidshq
   - Updated pt_PT Translation thx @jfig
@@ -342,11 +326,11 @@ Clean rebuild
   - Update to Gulp 4
   - Moving closing primary </div> into right-sidebar-check.php
   - Adding hero canvas widget pos
-  - Swap customized walker to latest upstream wp-bootstrap-navwalker class - Thx @pattonwebz
+  - Swap customized walker to the latest upstream wp-bootstrap-navwalker class - Thx @pattonwebz
   - gulp-rev - Thx @0dp
   - Update pagination - thx @0dp
   - Adding german formal language - Thx @Thomas-A-Reinert
-  - Added cookies checkbox support for inc/custom-comments.php - Thx @Jean Pierre Kolb
+  - Added cookie checkbox support for inc/custom-comments.php - Thx @Jean Pierre Kolb
   - Create Japanese translation - Thx @teruteru128
   - WooCommerce 3.4.0 update - Thx @ZacharyElkins
   - Organize sidebar files into loop-templates directory - Thx @axlright
@@ -356,7 +340,7 @@ Clean rebuild
 ## Release 0.8.2 April 11th 2018
   - Update to Bootstrap 4.1
   - Adding CONTRIBUTING.md and ISSUE_TEMPLATE.md - Thx @Thomas-A-Reinert
-  - Adding empty JS file into build process for adding own JS more easily - Thx @Thomas-A-Reinert
+  - Adding empty JavaScripot file into build process for adding own JS more easily - Thx @Thomas-A-Reinert
   - WooCommerce update and cleanup - Thx @ZacharyElkins
   - Adding SASS source map functionality - Thx @axlright
   - Cleanup - Thx @axlright
@@ -365,7 +349,7 @@ Clean rebuild
   - New pagination - Thx @0dp
   - Update functions.php - Thx @0dp
   - Add pluggable functions - Thx @axlright
-  - Add polish translation - Thx @mirzal
+  - Add Polish translation - Thx @mirzal
   - Adding timestamp to js and css resources to prevent caching while developinh - Thx @@gintsmurans
   - Improve left sidebar check - Thx @ZacharyElkins
 
@@ -387,7 +371,7 @@ Clean rebuild
   - Adding gulpconfig - Thx @lilolbear
   - Enable woocommerce product gallery slider by default. - Thx @typeplus
 
-## Release 0.8.0 January 22th 2018
+## Release 0.8.0 January 22nd 2018
   - Update to Bootstrap 4 (no more Beta...)
 
 
@@ -470,7 +454,7 @@ Clean rebuild
 ## Release 0.6.1 May 18th 2017
    - Replacing some older BS3 markup - Thx @typeplus and @Kostas Vrouvas
    - Add basic error handling for `gulp-plumber` - thx @L422Y
-   - Correcting woo commerce customer login markup
+   - Correcting WooCommerce customer login markup
    - Replacing cssnano with minify-css
    - Fix deprecated product accessor for WooCommerce 3.0 - Thx @willgorham
    - Declare woocommerce support - Thx @typeplus
@@ -481,7 +465,7 @@ Clean rebuild
    - Streamline 404.php and aligning with other page templates
    - Adding gulp-sequence
 
-## Release 0.6.0 (skipping 0.5.8 and 0.5.9 ) Apr. 21th 2017
+## Release 0.6.0 (skipping 0.5.8 and 0.5.9 ) Apr. 21st 2017
    - Adding WooCommerce 3.0.0 support - Big thx @typeplus
    - Add npm-debug.log to .gitignore file - thx @OussamaElgoumri
    - Adding swedish translation files
@@ -663,8 +647,8 @@ Clean rebuild
 
 ##  0.3.4 SEP. 9th 2015
    - Adding basic WooCommerce support
-   - Cleanup for submitting to wordpress.org
-   - Removing s SASS ... no need for basic styling. Thats Bootstrap´s job.
+   - Cleanup for submitting to WordPress.org
+   - Removing s SASS ... no need for basic styling. That's Bootstrap´s job.
 
 
 ##  0.3.1 AUG. 12th 2015
@@ -676,7 +660,7 @@ Clean rebuild
 ##  0.2.9 Mar. 10th 2015
    - Adding a new theme customizer option. It lets you add a code snippet right before the closing </body> tag.
 	   For example for Google Analytics, Google Tag Mananger, Pingdom etc. Just copy and past your code to the input field and save the setting.
-	   So you don´t have to edit the theme source file´s directly and your theme stay´s updateable
+	   So you don´t have to edit the theme source file´s directly, and your theme stay´s updateable
 
 ##  0.2.8 Feb. 6th 2015
    - Adding Grunt and Grunt SASS task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Reverts WooCommerce Translations to woocommerce language domain.
   - Updates understrap.pot file to include several translation strings that had not been added.
   - Fixes spelling and grammar errors in the CHANGELOG.md.
+  - replaces esc_attr with esc_html in Woocommerce cart template.
 
 
 

--- a/languages/understrap.pot
+++ b/languages/understrap.pot
@@ -1,774 +1,402 @@
-#, fuzzy
+# Copyright (C) 2021 the Understrap Authors
+# This file is distributed under the UnderStrap WordPress Theme, Copyright 2013-2021 Howard Development &amp; Consulting.
 msgid ""
 msgstr ""
-"Project-Id-Version: understrap\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/support/theme/_s\n"
-"POT-Creation-Date: 2018-06-17 17:56+0000\n"
-"POT-Revision-Date: Mon Jul 04 2016 09:13:18 GMT+0200 (CEST)\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Project-Id-Version: UnderStrap 0.9.6\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/theme/understrap\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: \n"
-"Language: \n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-SourceCharset: UTF-8\n"
-"X-Generator: Loco https://localise.biz/\n"
-"X-Poedit-KeywordsList: _:1;gettext:1;dgettext:2;ngettext:1,2;dngettext:2,3;"
-"__:1;_e:1;_c:1;_n:1,2;_n_noop:1,2;_nc:1,2;__ngettext:1,2;__ngettext_noop:1,2;"
-"_x:1,2c;_ex:1,2c;_nx:1,2,4c;_nx_noop:1,2,3c;_n_js:1,2;_nx_js:1,2,3c;"
-"esc_attr__:1;esc_html__:1;esc_attr_e:1;esc_html_e:1;esc_attr_x:1,2c;"
-"esc_html_x:1,2c;comments_number_link:2,3;t:1;st:1;trans:1;transChoice:1,2\n"
-"X-Poedit-Basepath: ..\n"
-"X-Poedit-SearchPath-0: footer.php\n"
-"X-Poedit-SearchPath-1: header.php\n"
-"X-Poedit-SearchPath-2: index.php\n"
-"X-Poedit-SearchPath-3: statichero.php\n"
-"X-Poedit-SearchPath-4: 404.php\n"
-"X-Poedit-SearchPath-5: archive.php\n"
-"X-Poedit-SearchPath-6: search.php\n"
-"X-Poedit-SearchPath-7: sticky.php\n"
-"X-Poedit-SearchPath-8: single.php\n"
-"X-Poedit-SearchPath-9: sidebar.php\n"
-"X-Poedit-SearchPath-10: comment-form.php\n"
-"X-Poedit-SearchPath-11: comments.php\n"
-"X-Poedit-SearchPath-12: content-none.php\n"
-"X-Poedit-SearchPath-13: content-page.php\n"
-"X-Poedit-SearchPath-14: content-search.php\n"
-"X-Poedit-SearchPath-15: content-single.php\n"
-"X-Poedit-SearchPath-16: content.php\n"
-"X-Poedit-SearchPath-17: hero.php\n"
-"X-Poedit-SearchPath-18: page.php\n"
-"X-Poedit-SearchPath-19: functions.php\n"
-"X-Poedit-SearchPath-20: page-templates\n"
-"X-Poedit-SearchPath-21: inc"
+"POT-Creation-Date: 2021-07-02T07:47:20+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.4.0\n"
+"X-Domain: understrap\n"
 
-#: search.php:29
-#, php-format
-msgid "Search Results for: %s"
+#. Theme Name of the theme
+msgid "UnderStrap"
 msgstr ""
 
-#: header.php:34
-msgid "Skip to content"
+#. Theme URI of the theme
+#: inc/hooks.php:40
+msgid "https://understrap.com"
 msgstr ""
 
-#: 404.php:24
+#. Description of the theme
+msgid "Combination of Automattic´s _s theme and Bootstrap 4. Made as a solid starting point for your next theme project and WordPress website. Use it as starter theme or as a parent theme. It is up to you. Including Font Awesome support, built-in widget slider and much more you need for basic websites. IMPORTANT: All developer dependencies are not bundled with this install file. Just download the .zip, extract it and run \"npm install\" and \"gulp copy-assets\" inside the extracted /understrap folder."
+msgstr ""
+
+#. Author of the theme
+msgid "the Understrap Authors"
+msgstr ""
+
+#. Author URI of the theme
+msgid "https://github.com/understrap/understrap/graphs/contributors"
+msgstr ""
+
+#: 404.php:30
 msgid "Oops! That page can&rsquo;t be found."
 msgstr ""
 
-#: 404.php:31
-msgid ""
-"It looks like nothing was found at this location. Maybe try one of the links "
-"below or a search?"
+#: 404.php:36
+msgid "It looks like nothing was found at this location. Maybe try one of the links below or a search?"
 msgstr ""
 
-#: 404.php:42
+#: 404.php:46
 msgid "Most Used Categories"
 msgstr ""
 
 #. translators: %1$s: smiley
-#: 404.php:62
-#, php-format
+#: 404.php:69
 msgid "Try looking in the monthly archives. %1$s"
 msgstr ""
 
-#: author.php:34
+#: author.php:38
 msgid "About:"
 msgstr ""
 
-#: author.php:42 inc/custom-comments.php:30
+#: author.php:49
 msgid "Website"
 msgstr ""
 
-#: author.php:49
+#: author.php:56
 msgid "Profile"
 msgstr ""
 
-#: author.php:54
+#: author.php:62
 msgid "Posts by"
 msgstr ""
 
-#: author.php:68
+#: author.php:75
+msgid "Permanent Link:"
+msgstr ""
+
+#: author.php:79
 msgid "in"
 msgstr ""
 
-#: comments.php:28
-#, php-format
+#. translators: %s: post title
+#: comments.php:37
 msgctxt "comments title"
-msgid "One thought on &ldquo;%2$s&rdquo;"
+msgid "One thought on &ldquo;%s&rdquo;"
+msgstr ""
+
+#. translators: 1: number of comments, 2: post title
+#: comments.php:44
+msgctxt "comments title"
+msgid "%1$s thought on &ldquo;%2$s&rdquo;"
 msgid_plural "%1$s thoughts on &ldquo;%2$s&rdquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: comments.php:36 comments.php:59
+#: comments.php:64
+#: comments.php:99
 msgid "Comment navigation"
 msgstr ""
 
-#: comments.php:38 comments.php:61
+#: comments.php:68
+#: comments.php:103
 msgid "&larr; Older Comments"
 msgstr ""
 
-#: comments.php:42 comments.php:65
+#: comments.php:74
+#: comments.php:109
 msgid "Newer Comments &rarr;"
 msgstr ""
 
-#: comments.php:78
+#: header.php:31
+msgid "Skip to content"
+msgstr ""
+
+#: header.php:36
+msgid "Main Navigation"
+msgstr ""
+
+#: header.php:63
+msgid "Toggle navigation"
+msgstr ""
+
+#: inc/class-wp-bootstrap-navwalker.php:376
+msgid "Add a menu"
+msgstr ""
+
+#: inc/custom-comments.php:102
 msgid "Comments are closed."
 msgstr ""
 
-#: footer.php:27
-msgid "http://wordpress.org/"
+#: inc/custom-header.php:54
+msgid "Default Header Image"
 msgstr ""
 
-#: footer.php:28
-#, php-format
-msgid "Proudly powered by %s"
+#: inc/customizer.php:42
+msgid "Theme Layout Settings"
 msgstr ""
 
-#: footer.php:31
-#, php-format
-msgid "Theme: %1$s by %2$s."
+#: inc/customizer.php:44
+msgid "Container width and sidebar defaults"
 msgstr ""
 
-#: footer.php:33
-#, php-format
-msgid "Version: %1$s"
+#: inc/customizer.php:84
+msgid "Container Width"
 msgstr ""
 
-#: searchform.php:10 searchform.php:16
-msgid "Search"
+#: inc/customizer.php:85
+msgid "Choose between Bootstrap's container and container-fluid"
 msgstr ""
 
-#: searchform.php:13
-msgid "Search &hellip;"
+#: inc/customizer.php:90
+msgid "Fixed width container"
 msgstr ""
 
-#: loop-templates/content-card.php:43 loop-templates/content-page.php:25
-#: loop-templates/content.php:37 loop-templates/content-single.php:31
-#: loop-templates/content-verticalpage.php:28
-msgid "Pages:"
+#: inc/customizer.php:91
+msgid "Full width container"
 msgstr ""
 
-#: loop-templates/content-page.php:34
-#: loop-templates/content-verticalpage.php:37
-msgid "Edit"
+#: inc/customizer.php:113
+msgid "Sidebar Positioning"
 msgstr ""
 
-#: loop-templates/content-none.php:15
-msgid "Nothing Found"
+#: inc/customizer.php:114
+msgid "Set sidebar's default position. Can either be: right, left, both or none. Note: this can be overridden on individual pages."
 msgstr ""
 
-#: loop-templates/content-none.php:23
-#, php-format
-msgid ""
-"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+#: inc/customizer.php:123
+msgid "Right sidebar"
 msgstr ""
 
-#: loop-templates/content-none.php:28
-msgid ""
-"Sorry, but nothing matched your search terms. Please try again with some "
-"different keywords."
+#: inc/customizer.php:124
+msgid "Left sidebar"
 msgstr ""
 
-#: loop-templates/content-none.php:34
-msgid ""
-"It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps "
-"searching can help."
+#: inc/customizer.php:125
+msgid "Left & Right sidebars"
 msgstr ""
 
-#. Name of the template
-msgid "Blank Page Template"
+#: inc/customizer.php:126
+msgid "No sidebar"
 msgstr ""
 
-#. Name of the template
-msgid "Left and Right Sidebar Layout"
-msgstr ""
-
-#. Name of the template
-msgid "Empty Page Template"
-msgstr ""
-
-#. Name of the template
-msgid "Full Width Page"
-msgstr ""
-
-#. Name of the template
-msgid "Left Sidebar Layout"
-msgstr ""
-
-#. Name of the template
-msgid "Vertical One Page"
-msgstr ""
-
-#: inc/template-tags.php:18
-#, php-format
-msgid " Edited %4$s"
-msgstr ""
-
-#: inc/template-tags.php:29
-#, php-format
-msgctxt "post date"
-msgid "Posted on %s"
-msgstr ""
-
-#: inc/template-tags.php:34
-#, php-format
-msgctxt "post author"
-msgid "by %s"
-msgstr ""
-
-#. translators: used between list items, there is a space after the comma
-#: inc/template-tags.php:51 inc/template-tags.php:57
-msgid ", "
-msgstr ""
-
-#: inc/template-tags.php:53
-#, php-format
-msgid "Posted in %1$s"
-msgstr ""
-
-#: inc/template-tags.php:59
-#, php-format
-msgid "Tagged %1$s"
-msgstr ""
-
-#: inc/template-tags.php:65
-msgid "Leave a comment"
-msgstr ""
-
-#: inc/template-tags.php:65
-msgid "1 Comment"
-msgstr ""
-
-#: inc/template-tags.php:65
-msgid "% Comments"
-msgstr ""
-
-#. translators: %s: Name of current post
-#: inc/template-tags.php:72
-#, php-format
-msgid "Edit %s"
-msgstr ""
-
-#: inc/template-tags.php:143
+#: inc/extras.php:80
 msgid "Post navigation"
 msgstr ""
 
-#: inc/template-tags.php:148
+#: inc/extras.php:84
 msgctxt "Previous post link"
 msgid "<i class=\"fa fa-angle-left\"></i>&nbsp;%title"
 msgstr ""
 
-#: inc/template-tags.php:151
+#: inc/extras.php:87
 msgctxt "Next post link"
 msgid "%title&nbsp;<i class=\"fa fa-angle-right\"></i>"
 msgstr ""
 
-#: inc/setup.php:51
+#: inc/hooks.php:30
+msgid "https://wordpress.org/"
+msgstr ""
+
+#. translators: WordPress
+#: inc/hooks.php:33
+msgid "Proudly powered by %s"
+msgstr ""
+
+#. translators: 1: Theme name, 2: Theme author
+#: inc/hooks.php:38
+msgid "Theme: %1$s by %2$s."
+msgstr ""
+
+#. translators: Theme version
+#: inc/hooks.php:44
+msgid "Version: %1$s"
+msgstr ""
+
+#: inc/pagination.php:53
+msgid "&laquo;"
+msgstr ""
+
+#: inc/pagination.php:54
+msgid "&raquo;"
+msgstr ""
+
+#: inc/pagination.php:57
+msgid "Posts navigation"
+msgstr ""
+
+#: inc/setup.php:49
 msgid "Primary Menu"
 msgstr ""
 
-#: inc/setup.php:122
+#: inc/setup.php:150
 msgid "Read More..."
 msgstr ""
 
-#: inc/widgets.php:14
+#: inc/template-tags.php:33
+msgctxt "post date"
+msgid "Posted on"
+msgstr ""
+
+#: inc/template-tags.php:42
+msgctxt "post author"
+msgid "by"
+msgstr ""
+
+#: inc/template-tags.php:42
+msgctxt "post author"
+msgid "Posted by"
+msgstr ""
+
+#. translators: used between list items, there is a space after the comma
+#: inc/template-tags.php:59
+#: inc/template-tags.php:65
+msgid ", "
+msgstr ""
+
+#. translators: %s: Categories of current post
+#: inc/template-tags.php:62
+msgid "Posted in %s"
+msgstr ""
+
+#. translators: %s: Tags of current post
+#: inc/template-tags.php:68
+msgid "Tagged %s"
+msgstr ""
+
+#: inc/template-tags.php:73
+msgid "Leave a comment"
+msgstr ""
+
+#: inc/template-tags.php:73
+msgid "1 Comment"
+msgstr ""
+
+#: inc/template-tags.php:73
+msgid "% Comments"
+msgstr ""
+
+#. translators: %s: Name of current post
+#: inc/template-tags.php:79
+msgid "Edit %s"
+msgstr ""
+
+#: inc/widgets.php:103
 msgid "Right Sidebar"
 msgstr ""
 
-#: inc/widgets.php:24
+#: inc/widgets.php:105
+msgid "Right sidebar widget area"
+msgstr ""
+
+#: inc/widgets.php:115
 msgid "Left Sidebar"
 msgstr ""
 
-#: inc/widgets.php:34
+#: inc/widgets.php:117
+msgid "Left sidebar widget area"
+msgstr ""
+
+#: inc/widgets.php:127
 msgid "Hero Slider"
 msgstr ""
 
-#: inc/widgets.php:44
-msgid "Hero Static"
+#: inc/widgets.php:129
+msgid "Hero slider area. Place two or more widgets here and they will slide!"
 msgstr ""
 
-#: inc/widgets.php:54
+#: inc/widgets.php:139
+msgid "Hero Canvas"
+msgstr ""
+
+#: inc/widgets.php:141
+msgid "Full size canvas hero area for Bootstrap and other custom HTML markup"
+msgstr ""
+
+#: inc/widgets.php:151
+msgid "Top Full"
+msgstr ""
+
+#: inc/widgets.php:153
+msgid "Full top widget with dynamic grid"
+msgstr ""
+
+#: inc/widgets.php:163
 msgid "Footer Full"
 msgstr ""
 
-#: inc/custom-comments.php:24
-msgid "Name"
+#: inc/widgets.php:165
+msgid "Full sized footer widget with dynamic grid"
 msgstr ""
 
-#: inc/custom-comments.php:27
-msgid "Email"
+#: loop-templates/content-none.php:18
+msgid "Nothing Found"
 msgstr ""
 
-#: inc/custom-comments.php:49
-msgctxt "noun"
-msgid "Comment"
+#. translators: 1: Link to WP admin new post page.
+#: loop-templates/content-none.php:30
+msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 
-#: inc/customizer.php:36
-msgid "Slider Settings"
+#: loop-templates/content-none.php:38
+msgid "Sorry, but nothing matched your search terms. Please try again with some different keywords."
 msgstr ""
 
-#: inc/customizer.php:45
-msgid "Number of slides displaying at once"
+#: loop-templates/content-none.php:46
+msgid "It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help."
 msgstr ""
 
-#: inc/customizer.php:57
-msgid "Slider Time (in ms)"
+#: loop-templates/content-page.php:29
+#: loop-templates/content-single.php:35
+#: loop-templates/content.php:42
+msgid "Pages:"
 msgstr ""
 
-#: inc/customizer.php:69
-msgid "Loop Slider Content"
+#: loop-templates/content-page.php:39
+msgid "Edit"
 msgstr ""
 
-#: inc/customizer.php:81
-msgid "Theme Layout Settings"
+#. Template Name of the theme
+msgid "Blank Page Template"
 msgstr ""
 
-#: inc/customizer.php:83
-msgid "Container width and sidebar defaults"
+#. Template Name of the theme
+msgid "Left and Right Sidebar Layout"
 msgstr ""
 
-#: inc/customizer.php:98
-msgid "Container Width"
+#. Template Name of the theme
+msgid "Empty Page Template"
 msgstr ""
 
-#: inc/customizer.php:99
-msgid "Choose between Bootstrap's container and container-fluid"
+#. Template Name of the theme
+msgid "Full Width Page"
 msgstr ""
 
-#: inc/customizer.php:104
-msgid "Fixed width container"
+#. Template Name of the theme
+msgid "Left Sidebar Layout"
 msgstr ""
 
-#: inc/customizer.php:105
-msgid "Full width container"
+#. Template Name of the theme
+msgid "Right Sidebar Layout"
 msgstr ""
 
-#: inc/customizer.php:122
-msgid "Sidebar Positioning"
+#. translators: %s: query term
+#: search.php:36
+msgid "Search Results for: %s"
 msgstr ""
 
-#: inc/customizer.php:123
-msgid "Set sidebar's position. Can either be: right, left, both or none"
+#: searchform.php:13
+#: searchform.php:19
+msgid "Search"
 msgstr ""
 
-#: inc/customizer.php:129
-msgid "Right sidebar"
+#: searchform.php:16
+msgid "Search &hellip;"
 msgstr ""
 
-#: inc/customizer.php:130
-msgid "Left sidebar"
-msgstr ""
-
-#: inc/customizer.php:131
-msgid "Left & Right sidebars"
-msgstr ""
-
-#: inc/customizer.php:132
-msgid "No sidebar"
-msgstr ""
-
-#: inc/customizer.php:150
-msgid "Posts Index Style"
-msgstr ""
-
-#: inc/customizer.php:151
-msgid "Choose how to display latest posts"
-msgstr ""
-
-#: inc/customizer.php:156
-msgid "Default"
-msgstr ""
-
-#: inc/customizer.php:157
-msgid "Masonry"
-msgstr ""
-
-#: inc/customizer.php:158
-msgid "Grid"
-msgstr ""
-
-#: inc/customizer.php:187
-msgid "Grid Post Columns"
-msgstr ""
-
-#: inc/customizer.php:188
-msgid "Choose how many columns to use"
-msgstr ""
-
-#: woocommerce/cart/proceed-to-checkout-button.php:27
-msgid "Proceed to Checkout"
-msgstr ""
-
-#: woocommerce/cart/mini-cart.php:49 woocommerce/cart/cart.php:60
-msgid "Remove this item"
-msgstr ""
-
-#: woocommerce/cart/mini-cart.php:72
-msgid "No products in the cart."
-msgstr ""
-
-#: woocommerce/cart/mini-cart.php:80
-msgid "Subtotal"
-msgstr ""
-
-#: woocommerce/cart/mini-cart.php:85
-msgid "View Cart"
-msgstr ""
-
-#: woocommerce/cart/mini-cart.php:86
-msgid "Checkout"
-msgstr ""
-
-#: woocommerce/cart/cart-empty.php:28
-msgid "Your cart is currently empty."
-msgstr ""
-
-#: woocommerce/cart/cart-empty.php:36
-msgid "Return To Shop"
-msgstr ""
-
-#: woocommerce/cart/cart.php:36 woocommerce/cart/cart.php:79
-#: woocommerce/checkout/form-pay.php:29
-msgid "Product"
-msgstr ""
-
-#: woocommerce/cart/cart.php:37 woocommerce/cart/cart.php:97
-msgid "Price"
-msgstr ""
-
-#: woocommerce/cart/cart.php:38 woocommerce/cart/cart.php:103
-msgid "Quantity"
-msgstr ""
-
-#: woocommerce/cart/cart.php:39 woocommerce/cart/cart.php:120
-#: woocommerce/myaccount/my-orders.php:16
-msgid "Total"
-msgstr ""
-
-#: woocommerce/cart/cart.php:92
-msgid "Available on backorder"
-msgstr ""
-
-#: woocommerce/cart/cart.php:138
-msgid "Coupon:"
-msgstr ""
-
-#: woocommerce/cart/cart.php:138 woocommerce/checkout/form-coupon.php:36
-msgid "Coupon code"
-msgstr ""
-
-#: woocommerce/cart/cart.php:138 woocommerce/checkout/form-coupon.php:40
-msgid "Apply Coupon"
-msgstr ""
-
-#: woocommerce/cart/cart.php:144
-msgid "Update Cart"
-msgstr ""
-
-#: woocommerce/checkout/payment.php:35
-msgid ""
-"Sorry, it seems that there are no available payment methods for your state. "
-"Please contact us if you require assistance or wish to make alternate "
-"arrangements."
-msgstr ""
-
-#: woocommerce/checkout/payment.php:35
-msgid "Please fill in your details above to see available payment methods."
-msgstr ""
-
-#: woocommerce/checkout/payment.php:42
-msgid ""
-"Since your browser does not support JavaScript, or it is disabled, please "
-"ensure you click the <em>Update Totals</em> button before placing your order."
-" You may be charged more than the amount stated above if you fail to do so."
-msgstr ""
-
-#: woocommerce/checkout/payment.php:43
-msgid "Update totals"
-msgstr ""
-
-#: woocommerce/checkout/form-pay.php:30
-msgid "Qty"
-msgstr ""
-
-#: woocommerce/checkout/form-pay.php:31
-msgid "Totals"
-msgstr ""
-
-#: woocommerce/checkout/form-pay.php:79
-msgid ""
-"Sorry, it seems that there are no available payment methods for your "
-"location. Please contact us if you require assistance or wish to make "
-"alternate arrangements."
-msgstr ""
-
-#: woocommerce/checkout/form-coupon.php:28
-msgid "Have a coupon?"
-msgstr ""
-
-#: woocommerce/checkout/form-coupon.php:28
-msgid "Click here to enter your code"
-msgstr ""
-
-#: woocommerce/global/form-login.php:35
-#: woocommerce/myaccount/form-lost-password.php:30
-msgid "Username or email"
-msgstr ""
-
-#: woocommerce/global/form-login.php:39 woocommerce/myaccount/form-login.php:48
-#: woocommerce/myaccount/form-login.php:98
-msgid "Password"
-msgstr ""
-
-#: woocommerce/global/form-login.php:48 woocommerce/myaccount/form-login.php:37
-#: woocommerce/myaccount/form-login.php:56
-msgid "Login"
-msgstr ""
-
-#: woocommerce/global/form-login.php:51 woocommerce/myaccount/form-login.php:58
-msgid "Remember me"
-msgstr ""
-
-#: woocommerce/global/form-login.php:55 woocommerce/myaccount/form-login.php:62
-msgid "Lost your password?"
-msgstr ""
-
-#: woocommerce/global/quantity-input.php:24
-msgctxt "Product quantity input tooltip"
-msgid "Qty"
-msgstr ""
-
-#: woocommerce/myaccount/form-lost-password.php:27
-msgid ""
-"Lost your password? Please enter your username or email address. You will "
-"receive a link to create a new password via email."
-msgstr ""
-
-#: woocommerce/myaccount/form-lost-password.php:40
-msgid "Reset Password"
-msgstr ""
-
-#: woocommerce/myaccount/form-login.php:44
-msgid "Username or email address"
-msgstr ""
-
-#: woocommerce/myaccount/form-login.php:75
-#: woocommerce/myaccount/form-login.php:112
-msgid "Register"
-msgstr ""
-
-#: woocommerce/myaccount/form-login.php:84
-msgid "Username"
-msgstr ""
-
-#: woocommerce/myaccount/form-login.php:91
-#: woocommerce/myaccount/form-edit-account.php:40
-msgid "Email address"
-msgstr ""
-
-#: woocommerce/myaccount/form-login.php:105
-msgid "Anti-spam"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-account.php:30
-msgid "First name"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-account.php:34
-msgid "Last name"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-account.php:45
-msgid "Password Change"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-account.php:48
-msgid "Current Password (leave blank to leave unchanged)"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-account.php:52
-msgid "New Password (leave blank to leave unchanged)"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-account.php:56
-msgid "Confirm New Password"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-account.php:66
-msgid "Save changes"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:13
-msgid "Order"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:14
-msgid "Date"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:15
-msgid "Status"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:30
-msgid "Recent Orders"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:55 woocommerce/myaccount/orders.php:51
-msgctxt "hash before order number"
-msgid "#"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:65 woocommerce/myaccount/orders.php:61
-#, php-format
-msgid "%s for %s item"
-msgid_plural "%s for %s items"
-msgstr[0] ""
-msgstr[1] ""
-
-#: woocommerce/myaccount/my-orders.php:72 woocommerce/myaccount/orders.php:68
-msgid "Pay"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:76 woocommerce/myaccount/orders.php:72
-msgid "View"
-msgstr ""
-
-#: woocommerce/myaccount/my-orders.php:80 woocommerce/myaccount/orders.php:76
-msgid "Cancel"
-msgstr ""
-
-#: woocommerce/myaccount/orders.php:107
+#: sidebar-templates/sidebar-hero.php:28
+#: woocommerce/myaccount/orders.php:89
 msgid "Previous"
 msgstr ""
 
-#: woocommerce/myaccount/orders.php:111
+#: sidebar-templates/sidebar-hero.php:36
+#: woocommerce/myaccount/orders.php:93
 msgid "Next"
-msgstr ""
-
-#: woocommerce/myaccount/orders.php:119 woocommerce/myaccount/downloads.php:98
-msgid "Go Shop"
-msgstr ""
-
-#: woocommerce/myaccount/orders.php:121
-msgid "No order has been made yet."
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-address.php:23
-msgid "Billing Address"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-address.php:23
-msgid "Shipping Address"
-msgstr ""
-
-#: woocommerce/myaccount/form-edit-address.php:46
-msgid "Save Address"
-msgstr ""
-
-#: woocommerce/myaccount/form-reset-password.php:27
-msgid "Enter a new password below."
-msgstr ""
-
-#: woocommerce/myaccount/form-reset-password.php:30
-msgid "New password"
-msgstr ""
-
-#: woocommerce/myaccount/form-reset-password.php:34
-msgid "Re-enter new password"
-msgstr ""
-
-#: woocommerce/myaccount/form-reset-password.php:47
-msgid "Save"
-msgstr ""
-
-#: woocommerce/myaccount/downloads.php:59
-msgid "&infin;"
-msgstr ""
-
-#: woocommerce/myaccount/downloads.php:67
-msgid "Never"
-msgstr ""
-
-#: woocommerce/myaccount/downloads.php:75
-msgid "Download"
-msgstr ""
-
-#: woocommerce/myaccount/downloads.php:100
-msgid "No downloads available yet."
-msgstr ""
-
-#: woocommerce/single-product/review-rating.php:28
-#, php-format
-msgid "Rated %d out of 5"
-msgstr ""
-
-#: woocommerce/single-product/review-rating.php:29
-msgid "out of 5"
-msgstr ""
-
-#: woocommerce/single-product/rating.php:36
-#, php-format
-msgid "Rated %s out of 5"
-msgstr ""
-
-#: woocommerce/single-product/rating.php:38
-#, php-format
-msgid "out of %s5%s"
-msgstr ""
-
-#: woocommerce/single-product/rating.php:39
-#, php-format
-msgid "based on %s customer rating"
-msgid_plural "based on %s customer ratings"
-msgstr[0] ""
-msgstr[1] ""
-
-#: woocommerce/single-product/rating.php:42
-#, php-format
-msgid "%s customer review"
-msgid_plural "%s customer reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#. Name of the theme
-msgid "UnderStrap"
-msgstr ""
-
-#. Description of the theme
-msgid ""
-"Combination of Automattic´s _s theme and Bootstrap 4. Made as a solid "
-"starting point for your next theme project and WordPress website. Use it as "
-"starter theme or as a parent theme. It is up to you. Including Font Awesome "
-"support, built-in widget slider and much more you need for basic websites. "
-"IMPORTANT: All developer dependencies are not bundled with this install file."
-" Just download the .zip, extract it and run \"npm install\" and \"gulp copy-"
-"assets\" inside the extracted /understrap folder."
-msgstr ""
-
-#. Theme URI of the theme
-msgid "http://understrap.com"
-msgstr ""
-
-#. Author of the theme
-msgid "Holger Koenemann"
-msgstr ""
-
-#. Author URI of the theme
-msgid "http://www.holgerkoenemann.de"
-msgstr ""
-
-msgid "Proceed to checkout"
-msgstr ""
-
-msgid "Apply coupon"
-msgstr ""
-
-msgid "Update cart"
-msgstr ""
-
-msgid "Your order"
 msgstr ""

--- a/woocommerce/cart/cart-empty.php
+++ b/woocommerce/cart/cart-empty.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'woocommerce_cart_is_empty' );
 
 if ( wc_get_page_id( 'shop' ) > 0 ) :
-?>
+	?>
 	<p class="return-to-shop">
 		<a class="btn btn-outline-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
 			<?php

--- a/woocommerce/cart/cart-empty.php
+++ b/woocommerce/cart/cart-empty.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,11 +23,20 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'woocommerce_cart_is_empty' );
 
 if ( wc_get_page_id( 'shop' ) > 0 ) :
-	?>
+?>
 	<p class="return-to-shop">
 		<a class="btn btn-outline-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Return to shop', 'understrap' ); ?>
+			<?php
+				/**
+				 * Filter "Return To Shop" text.
+				 *
+				 * @since 4.6.0
+				 * @param string $default_text Default text.
+				 */
+				echo esc_html( apply_filters( 'woocommerce_return_to_shop_text', __( 'Return to shop', 'woocommerce' ) ) );
+			?>
 		</a>
 	</p>
 	<?php
 endif;
+

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -27,10 +27,10 @@ do_action( 'woocommerce_before_cart' ); ?>
 			<tr>
 				<th class="product-remove">&nbsp;</th>
 				<th class="product-thumbnail">&nbsp;</th>
-				<th class="product-name"><?php esc_html_e( 'Product', 'understrap' ); ?></th>
-				<th class="product-price"><?php esc_html_e( 'Price', 'understrap' ); ?></th>
-				<th class="product-quantity"><?php esc_html_e( 'Quantity', 'understrap' ); ?></th>
-				<th class="product-subtotal"><?php esc_html_e( 'Subtotal', 'understrap' ); ?></th>
+				<th class="product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
+				<th class="product-price"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
+				<th class="product-quantity"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
+				<th class="product-subtotal"><?php esc_html_e( 'Subtotal', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -53,7 +53,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 									sprintf(
 										'<a href="%s" class="remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">&times;</a>',
 										esc_url( wc_get_cart_remove_url( $cart_item_key ) ),
-										esc_html__( 'Remove this item', 'understrap' ),
+										esc_html__( 'Remove this item', 'woocommerce' ),
 										esc_attr( $product_id ),
 										esc_attr( $_product->get_sku() )
 									),
@@ -74,7 +74,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 						?>
 						</td>
 
-						<td class="product-name" data-title="<?php esc_attr_e( 'Product', 'understrap' ); ?>">
+						<td class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
 						<?php
 						if ( ! $product_permalink ) {
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;' );
@@ -89,18 +89,18 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 						// Backorder notification.
 						if ( $_product->backorders_require_notification() && $_product->is_on_backorder( $cart_item['quantity'] ) ) {
-							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_backorder_notification', '<p class="backorder_notification">' . esc_html__( 'Available on backorder', 'understrap' ) . '</p>', $product_id ) );
+							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_backorder_notification', '<p class="backorder_notification">' . esc_html__( 'Available on backorder', 'woocommerce' ) . '</p>', $product_id ) );
 						}
 						?>
 						</td>
 
-						<td class="product-price" data-title="<?php esc_attr_e( 'Price', 'understrap' ); ?>">
+						<td class="product-price" data-title="<?php esc_attr_e( 'Price', 'woocommerce' ); ?>">
 							<?php
 								echo apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							?>
 						</td>
 
-						<td class="product-quantity" data-title="<?php esc_attr_e( 'Quantity', 'understrap' ); ?>">
+						<td class="product-quantity" data-title="<?php esc_attr_e( 'Quantity', 'woocommerce' ); ?>">
 						<?php
 						if ( $_product->is_sold_individually() ) {
 							$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', $cart_item_key );
@@ -122,7 +122,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 						?>
 						</td>
 
-						<td class="product-subtotal" data-title="<?php esc_attr_e( 'Subtotal', 'understrap' ); ?>">
+						<td class="product-subtotal" data-title="<?php esc_attr_e( 'Subtotal', 'woocommerce' ); ?>">
 							<?php
 								echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							?>
@@ -140,12 +140,12 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 					<?php if ( wc_coupons_enabled() ) { ?>
 						<div class="coupon">
-							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'understrap' ); ?></label> <input type="text" name="coupon_code" class="input-text form-control" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'understrap' ); ?>" /> <button type="submit" class="btn btn-outline-primary" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'understrap' ); ?>"><?php esc_attr_e( 'Apply coupon', 'understrap' ); ?></button>
+							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text form-control" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="btn btn-outline-primary" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
 							<?php do_action( 'woocommerce_cart_coupon' ); ?>
 						</div>
 					<?php } ?>
 
-					<button type="submit" class="btn btn-outline-primary" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'understrap' ); ?>"><?php esc_html_e( 'Update cart', 'understrap' ); ?></button>
+					<button type="submit" class="btn btn-outline-primary" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
 
 					<?php do_action( 'woocommerce_cart_actions' ); ?>
 
@@ -173,5 +173,5 @@ do_action( 'woocommerce_before_cart' ); ?>
 	?>
 </div>
 
-<?php
-do_action( 'woocommerce_after_cart' );
+<?php do_action( 'woocommerce_after_cart' ); ?>
+

--- a/woocommerce/cart/proceed-to-checkout-button.php
+++ b/woocommerce/cart/proceed-to-checkout-button.php
@@ -13,9 +13,8 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 2.4.0
  */
 
 // Exit if accessed directly.
@@ -23,5 +22,5 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="btn btn-primary btn-lg btn-block">
-	<?php esc_html_e( 'Proceed to checkout', 'understrap' ); ?>
+	<?php esc_html_e( 'Proceed to checkout', 'woocommerce' ); ?>
 </a>

--- a/woocommerce/checkout/form-checkout.php
+++ b/woocommerce/checkout/form-checkout.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -23,7 +23,7 @@ do_action( 'woocommerce_before_checkout_form', $checkout );
 
 // If checkout registration is disabled and not logged in, the user cannot checkout.
 if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_required() && ! is_user_logged_in() ) {
-	echo esc_html( apply_filters( 'woocommerce_checkout_must_be_logged_in_message', __( 'You must be logged in to checkout.', 'understrap' ) ) );
+	echo esc_html( apply_filters( 'woocommerce_checkout_must_be_logged_in_message', __( 'You must be logged in to checkout.', 'woocommerce' ) ) );
 	return;
 }
 
@@ -48,9 +48,11 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
 
 	<?php endif; ?>
-
-	<h3 id="order_review_heading"><?php esc_html_e( 'Your order', 'understrap' ); ?></h3>
-
+	
+	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
+	
+	<h3 id="order_review_heading"><?php esc_html_e( 'Your order', 'woocommerce' ); ?></h3>
+	
 	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
 
 	<div id="order_review" class="woocommerce-checkout-review-order">
@@ -61,5 +63,4 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 </form>
 
-<?php
-do_action( 'woocommerce_after_checkout_form', $checkout );
+<?php do_action( 'woocommerce_after_checkout_form', $checkout );

--- a/woocommerce/checkout/form-checkout.php
+++ b/woocommerce/checkout/form-checkout.php
@@ -48,11 +48,11 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
 
 	<?php endif; ?>
-	
+
 	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
-	
+
 	<h3 id="order_review_heading"><?php esc_html_e( 'Your order', 'woocommerce' ); ?></h3>
-	
+
 	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
 
 	<div id="order_review" class="woocommerce-checkout-review-order">
@@ -63,4 +63,5 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 </form>
 
-<?php do_action( 'woocommerce_after_checkout_form', $checkout );
+<?php
+do_action( 'woocommerce_after_checkout_form', $checkout );

--- a/woocommerce/checkout/form-coupon.php
+++ b/woocommerce/checkout/form-coupon.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.4.4
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,19 +23,19 @@ if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 
 ?>
 <div class="woocommerce-form-coupon-toggle">
-	<?php wc_print_notice( apply_filters( 'woocommerce_checkout_coupon_message', __( 'Have a coupon?', 'understrap' ) . ' <a href="#" class="showcoupon">' . __( 'Click here to enter your code', 'understrap' ) . '</a>' ), 'notice' ); ?>
+	<?php wc_print_notice( apply_filters( 'woocommerce_checkout_coupon_message', esc_html__( 'Have a coupon?', 'woocommerce' ) . ' <a href="#" class="showcoupon">' . esc_html__( 'Click here to enter your code', 'woocommerce' ) . '</a>' ), 'notice' ); ?>
 </div>
 
 <form class="checkout_coupon woocommerce-form-coupon" method="post" style="display:none">
 
-	<p><?php esc_html_e( 'If you have a coupon code, please apply it below.', 'understrap' ); ?></p>
+	<p><?php esc_html_e( 'If you have a coupon code, please apply it below.', 'woocommerce' ); ?></p>
 
 	<p class="form-row form-row-first">
-		<input type="text" name="coupon_code" class="form-control" placeholder="<?php esc_attr_e( 'Coupon code', 'understrap' ); ?>" id="coupon_code" value="" />
+		<input type="text" name="coupon_code" class="form-control" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" id="coupon_code" value="" />
 	</p>
 
 	<p class="form-row form-row-last">
-		<button type="submit" class="btn btn-outline-primary" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'understrap' ); ?>"><?php esc_html_e( 'Apply coupon', 'understrap' ); ?></button>
+		<button type="submit" class="btn btn-outline-primary" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
 	</p>
 
 	<div class="clear"></div>

--- a/woocommerce/checkout/form-pay.php
+++ b/woocommerce/checkout/form-pay.php
@@ -12,21 +12,21 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 5.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
-$item_totals = $order->get_order_item_totals();
+$item_totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 ?>
 <form id="order_review" method="post">
 
 	<table class="shop_table">
 		<thead>
 			<tr>
-				<th class="product-name"><?php esc_html_e( 'Product', 'understrap' ); ?></th>
-				<th class="product-quantity"><?php esc_html_e( 'Qty', 'understrap' ); ?></th>
-				<th class="product-total"><?php esc_html_e( 'Totals', 'understrap' ); ?></th>
+				<th class="product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
+				<th class="product-quantity"><?php esc_html_e( 'Qty', 'woocommerce' ); ?></th>
+				<th class="product-total"><?php esc_html_e( 'Totals', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -40,7 +40,7 @@ $item_totals = $order->get_order_item_totals();
 					<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
 						<td class="product-name">
 							<?php
-								echo apply_filters( 'woocommerce_order_item_name', esc_html( $item->get_name() ), $item, false ); // @codingStandardsIgnoreLine
+								echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) ); // @codingStandardsIgnoreLine
 
 								do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, false );
 
@@ -49,7 +49,7 @@ $item_totals = $order->get_order_item_totals();
 								do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, false );
 							?>
 						</td>
-						<td class="product-quantity"><?php echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', esc_html( $item->get_quantity() ) ) . '</strong>', $item ); ?></td><?php // @codingStandardsIgnoreLine ?>
+						<td class="product-quantity"><?php echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times;&nbsp;%s', esc_html( $item->get_quantity() ) ) . '</strong>', $item ); ?></td><?php // @codingStandardsIgnoreLine ?>
 						<td class="product-subtotal"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td><?php // @codingStandardsIgnoreLine ?>
 					</tr>
 				<?php endforeach; ?>
@@ -76,7 +76,7 @@ $item_totals = $order->get_order_item_totals();
 						wc_get_template( 'checkout/payment-method.php', array( 'gateway' => $gateway ) );
 					}
 				} else {
-					echo '<li class="woocommerce-notice woocommerce-notice--info woocommerce-info">' . apply_filters( 'woocommerce_no_available_payment_methods_message', __( 'Sorry, it seems that there are no available payment methods for your location. Please contact us if you require assistance or wish to make alternate arrangements.', 'understrap' ) ) . '</li>'; // @codingStandardsIgnoreLine
+					echo '<li class="woocommerce-notice woocommerce-notice--info woocommerce-info">' . apply_filters( 'woocommerce_no_available_payment_methods_message', esc_html__( 'Sorry, it seems that there are no available payment methods for your location. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' ) ) . '</li>'; // @codingStandardsIgnoreLine
 				}
 				?>
 			</ul>

--- a/woocommerce/checkout/payment.php
+++ b/woocommerce/checkout/payment.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.5.3
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -30,7 +30,7 @@ if ( ! is_ajax() ) {
 					wc_get_template( 'checkout/payment-method.php', array( 'gateway' => $gateway ) );
 				}
 			} else {
-				echo '<li class="woocommerce-notice woocommerce-notice--info woocommerce-info">' . apply_filters( 'woocommerce_no_available_payment_methods_message', WC()->customer->get_billing_country() ? esc_html__( 'Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'understrap' ) : esc_html__( 'Please fill in your details above to see available payment methods.', 'understrap' ) ) . '</li>'; // @codingStandardsIgnoreLine
+				echo '<li class="woocommerce-notice woocommerce-notice--info woocommerce-info">' . apply_filters( 'woocommerce_no_available_payment_methods_message', WC()->customer->get_billing_country() ? esc_html__( 'Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' ) : esc_html__( 'Please fill in your details above to see available payment methods.', 'woocommerce' ) ) . '</li>'; // @codingStandardsIgnoreLine
 			}
 			?>
 		</ul>
@@ -39,9 +39,9 @@ if ( ! is_ajax() ) {
 		<noscript>
 			<?php
 			/* translators: $1 and $2 opening and closing emphasis tags respectively */
-			printf( esc_html__( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the %1$sUpdate Totals%2$s button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'understrap' ), '<em>', '</em>' );
+			printf( esc_html__( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the %1$sUpdate Totals%2$s button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'woocommerce' ), '<em>', '</em>' );
 			?>
-			<br/><button type="submit" class="btn btn-primary" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'understrap' ); ?>"><?php esc_html_e( 'Update totals', 'understrap' ); ?></button>
+			<br/><button type="submit" class="btn btn-primary" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'woocommerce' ); ?>"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button>
 		</noscript>
 
 		<?php wc_get_template( 'checkout/terms.php' ); ?>

--- a/woocommerce/global/form-login.php
+++ b/woocommerce/global/form-login.php
@@ -12,11 +12,17 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.6.0
  */
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+
+
+
+
+
 
 if ( is_user_logged_in() ) {
 	return;
@@ -30,11 +36,11 @@ if ( is_user_logged_in() ) {
 	<?php echo ( $message ) ? wpautop( wptexturize( $message ) ) : ''; // @codingStandardsIgnoreLine ?>
 
 	<p class="form-row form-row-first">
-		<label for="username"><?php esc_html_e( 'Username or email', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="username"><?php esc_html_e( 'Username or email', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="text" class="input-text form-control" name="username" id="username" autocomplete="username" />
 	</p>
 	<p class="form-row form-row-last">
-		<label for="password"><?php esc_html_e( 'Password', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="password"><?php esc_html_e( 'Password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 		<input class="input-text form-control" type="password" name="password" id="password" autocomplete="current-password" />
 	</p>
 	<div class="clear"></div>
@@ -42,16 +48,16 @@ if ( is_user_logged_in() ) {
 	<?php do_action( 'woocommerce_login_form' ); ?>
 
 	<p class="form-row">
-		<label class="woocommerce-form__label woocommerce-form__label-for-checkbox">
-			<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'understrap' ); ?></span>
+		<label class="woocommerce-form__label woocommerce-form__label-for-checkbox woocommerce-form-login__rememberme">
+			<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 		</label>
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ); ?>" />
-		<button type="submit" class="btn btn-outline-primary" name="login" value="<?php esc_attr_e( 'Login', 'understrap' ); ?>"><?php esc_html_e( 'Login', 'understrap' ); ?></button>
+		<button type="submit" class="btn btn-outline-primary" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 
 	</p>
 	<p class="lost_password">
-		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'understrap' ); ?></a>
+		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
 	</p>
 
 	<div class="clear"></div>

--- a/woocommerce/loop/add-to-cart.php
+++ b/woocommerce/loop/add-to-cart.php
@@ -11,19 +11,17 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.3.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
 
 global $product;
 
-echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	'woocommerce_loop_add_to_cart_link',
+echo apply_filters(
+	'woocommerce_loop_add_to_cart_link', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	sprintf(
 		'<div class="add-to-cart-container"><a href="%s" data-quantity="%s" class="%s product_type_%s single_add_to_cart_button btn btn-outline-primary btn-block %s" %s> %s</a></div>',
 		esc_url( $product->add_to_cart_url() ),

--- a/woocommerce/loop/orderby.php
+++ b/woocommerce/loop/orderby.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <form class="woocommerce-ordering" method="get">
-	<select name="orderby" class="orderby custom-select" aria-label="<?php esc_attr_e( 'Shop order', 'understrap' ); ?>">
+	<select name="orderby" class="orderby custom-select" aria-label="<?php esc_attr_e( 'Shop order', 'woocommerce' ); ?>">
 		<?php foreach ( $catalog_orderby_options as $option_id => $name ) : ?>
 			<option value="<?php echo esc_attr( $option_id ); ?>" <?php selected( $orderby, $option_id ); ?>><?php echo esc_html( $name ); ?></option>
 		<?php endforeach; ?>

--- a/woocommerce/myaccount/downloads.php
+++ b/woocommerce/myaccount/downloads.php
@@ -43,4 +43,5 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 	</div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_account_downloads', $has_downloads );
+<?php
+do_action( 'woocommerce_after_account_downloads', $has_downloads );

--- a/woocommerce/myaccount/downloads.php
+++ b/woocommerce/myaccount/downloads.php
@@ -13,9 +13,8 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -38,11 +37,10 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 <?php else : ?>
 	<div class="woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="btn btn-outline-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go shop', 'understrap' ); ?>
+			<?php esc_html_e( 'Browse products', 'woocommerce' ); ?>
 		</a>
-		<?php esc_html_e( 'No downloads available yet.', 'understrap' ); ?>
+		<?php esc_html_e( 'No downloads available yet.', 'woocommerce' ); ?>
 	</div>
 <?php endif; ?>
 
-<?php
-do_action( 'woocommerce_after_account_downloads', $has_downloads );
+<?php do_action( 'woocommerce_after_account_downloads', $has_downloads );

--- a/woocommerce/myaccount/form-edit-account.php
+++ b/woocommerce/myaccount/form-edit-account.php
@@ -73,4 +73,5 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 	<?php do_action( 'woocommerce_edit_account_form_end' ); ?>
 </form>
 
-<?php do_action( 'woocommerce_after_edit_account_form' );
+<?php
+do_action( 'woocommerce_after_edit_account_form' );

--- a/woocommerce/myaccount/form-edit-account.php
+++ b/woocommerce/myaccount/form-edit-account.php
@@ -66,7 +66,7 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 
 	<p>
 		<?php wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
-		<button type="submit" class="btn btn-outline-primary" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'understrap' ); ?></button>
+		<button type="submit" class="btn btn-outline-primary" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 

--- a/woocommerce/myaccount/form-edit-account.php
+++ b/woocommerce/myaccount/form-edit-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -24,39 +24,39 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 	<?php do_action( 'woocommerce_edit_account_form_start' ); ?>
 
 	<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
-		<label for="account_first_name"><?php esc_html_e( 'First name', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="account_first_name"><?php esc_html_e( 'First name', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="account_first_name" id="account_first_name" autocomplete="given-name" value="<?php echo esc_attr( $user->first_name ); ?>" />
 	</p>
 	<p class="woocommerce-form-row woocommerce-form-row--last form-row form-row-last">
-		<label for="account_last_name"><?php esc_html_e( 'Last name', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="account_last_name"><?php esc_html_e( 'Last name', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="account_last_name" id="account_last_name" autocomplete="family-name" value="<?php echo esc_attr( $user->last_name ); ?>" />
 	</p>
 	<div class="clear"></div>
 
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-		<label for="account_display_name"><?php esc_html_e( 'Display name', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
-		<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="account_display_name" id="account_display_name" value="<?php echo esc_attr( $user->display_name ); ?>" /> <span><em><?php esc_html_e( 'This will be how your name will be displayed in the account section and in reviews', 'understrap' ); ?></em></span>
+		<label for="account_display_name"><?php esc_html_e( 'Display name', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
+		<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="account_display_name" id="account_display_name" value="<?php echo esc_attr( $user->display_name ); ?>" /> <span><em><?php esc_html_e( 'This will be how your name will be displayed in the account section and in reviews', 'woocommerce' ); ?></em></span>
 	</p>
 	<div class="clear"></div>
 
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-		<label for="account_email"><?php esc_html_e( 'Email address', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="account_email"><?php esc_html_e( 'Email address', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo esc_attr( $user->user_email ); ?>" />
 	</p>
 
 	<fieldset>
-		<legend><?php esc_html_e( 'Password change', 'understrap' ); ?></legend>
+		<legend><?php esc_html_e( 'Password change', 'woocommerce' ); ?></legend>
 
 		<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-			<label for="password_current"><?php esc_html_e( 'Current password (leave blank to leave unchanged)', 'understrap' ); ?></label>
+			<label for="password_current"><?php esc_html_e( 'Current password (leave blank to leave unchanged)', 'woocommerce' ); ?></label>
 			<input type="password" class="woocommerce-Input woocommerce-Input--password input-text" name="password_current" id="password_current" autocomplete="off" />
 		</p>
 		<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-			<label for="password_1"><?php esc_html_e( 'New password (leave blank to leave unchanged)', 'understrap' ); ?></label>
+			<label for="password_1"><?php esc_html_e( 'New password (leave blank to leave unchanged)', 'woocommerce' ); ?></label>
 			<input type="password" class="woocommerce-Input woocommerce-Input--password input-text" name="password_1" id="password_1" autocomplete="off" />
 		</p>
 		<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-			<label for="password_2"><?php esc_html_e( 'Confirm new password', 'understrap' ); ?></label>
+			<label for="password_2"><?php esc_html_e( 'Confirm new password', 'woocommerce' ); ?></label>
 			<input type="password" class="woocommerce-Input woocommerce-Input--password input-text" name="password_2" id="password_2" autocomplete="off" />
 		</p>
 	</fieldset>
@@ -66,12 +66,11 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 
 	<p>
 		<?php wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
-		<button type="submit" class="btn btn-outline-primary" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'understrap' ); ?>"><?php esc_html_e( 'Save changes', 'understrap' ); ?></button>
+		<button type="submit" class="btn btn-outline-primary" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'understrap' ); ?></button>
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 
 	<?php do_action( 'woocommerce_edit_account_form_end' ); ?>
 </form>
 
-<?php
-do_action( 'woocommerce_after_edit_account_form' );
+<?php do_action( 'woocommerce_after_edit_account_form' );

--- a/woocommerce/myaccount/form-edit-address.php
+++ b/woocommerce/myaccount/form-edit-address.php
@@ -53,4 +53,5 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_edit_account_address_form' );
+<?php
+do_action( 'woocommerce_after_edit_account_address_form' );

--- a/woocommerce/myaccount/form-edit-address.php
+++ b/woocommerce/myaccount/form-edit-address.php
@@ -12,12 +12,12 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
-$page_title = ( 'billing' === $load_address ) ? __( 'Billing address', 'understrap' ) : __( 'Shipping address', 'understrap' );
+$page_title = ( 'billing' === $load_address ) ? esc_html__( 'Billing address', 'woocommerce' ) : esc_html__( 'Shipping address', 'woocommerce' );
 
 do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 
@@ -43,7 +43,7 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 			<?php do_action( "woocommerce_after_edit_address_form_{$load_address}" ); ?>
 
 			<p>
-				<button type="submit" class="btn btn-outline-primary" name="save_address" value="<?php esc_attr_e( 'Save address', 'understrap' ); ?>"><?php esc_html_e( 'Save address', 'understrap' ); ?></button>
+				<button type="submit" class="btn btn-outline-primary" name="save_address" value="<?php esc_attr_e( 'Save address', 'woocommerce' ); ?>"><?php esc_html_e( 'Save address', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'woocommerce-edit_address', 'woocommerce-edit-address-nonce' ); ?>
 				<input type="hidden" name="action" value="edit_address" />
 			</p>
@@ -53,5 +53,4 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 
 <?php endif; ?>
 
-<?php
-do_action( 'woocommerce_after_edit_account_address_form' );
+<?php do_action( 'woocommerce_after_edit_account_address_form' );

--- a/woocommerce/myaccount/form-login.php
+++ b/woocommerce/myaccount/form-login.php
@@ -115,4 +115,5 @@ $col = 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ? 6 :
 </div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_customer_login_form' );
+<?php
+do_action( 'woocommerce_after_customer_login_form' );

--- a/woocommerce/myaccount/form-login.php
+++ b/woocommerce/myaccount/form-login.php
@@ -28,18 +28,18 @@ $col = 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ? 6 :
 
 	<div class="u-column1 col-md-<?php echo (int) $col; ?>">
 
-		<h2><?php esc_html_e( 'Login', 'understrap' ); ?></h2>
+		<h2><?php esc_html_e( 'Login', 'woocommerce' ); ?></h2>
 
 		<form class="woocommerce-form woocommerce-form-login login" method="post">
 
 			<?php do_action( 'woocommerce_login_form_start' ); ?>
 
 			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-				<label for="username"><?php esc_html_e( 'Username or email address', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+				<label for="username"><?php esc_html_e( 'Username or email address', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 				<input type="text" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="username" id="username" autocomplete="username" value="<?php echo ( ! empty( $_POST['username'] ) ) ? esc_attr( wp_unslash( $_POST['username'] ) ) : ''; ?>" /><?php // @codingStandardsIgnoreLine ?>
 			</p>
 			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-				<label for="password"><?php esc_html_e( 'Password', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+				<label for="password"><?php esc_html_e( 'Password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 				<input class="woocommerce-Input woocommerce-Input--text input-text form-control" type="password" name="password" id="password" autocomplete="current-password" />
 			</p>
 
@@ -47,13 +47,13 @@ $col = 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ? 6 :
 
 			<p class="form-row">
 				<label class="woocommerce-form__label woocommerce-form__label-for-checkbox woocommerce-form-login__rememberme w-100">
-					<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'understrap' ); ?></span>
+					<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 				</label>
 				<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-				<button type="submit" class="woocommerce-form-login__submit btn btn-outline-primary" name="login" value="<?php esc_attr_e( 'Log in', 'understrap' ); ?>"><?php esc_html_e( 'Log in', 'understrap' ); ?></button>
+				<button type="submit" class="woocommerce-form-login__submit btn btn-outline-primary" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
 			</p>
 			<p class="woocommerce-LostPassword lost_password">
-				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'understrap' ); ?></a>
+				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
 			</p>
 
 			<?php do_action( 'woocommerce_login_form_end' ); ?>
@@ -66,7 +66,7 @@ $col = 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ? 6 :
 
 	<div class="u-column2 col-md-6">
 
-		<h2><?php esc_html_e( 'Register', 'understrap' ); ?></h2>
+		<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
 
 		<form method="post" class="woocommerce-form woocommerce-form-register register" <?php do_action( 'woocommerce_register_form_tag' ); ?> >
 
@@ -75,27 +75,27 @@ $col = 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ? 6 :
 			<?php if ( 'no' === get_option( 'woocommerce_registration_generate_username' ) ) : ?>
 
 				<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-					<label for="reg_username"><?php esc_html_e( 'Username', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+					<label for="reg_username"><?php esc_html_e( 'Username', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 					<input type="text" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="username" id="reg_username" autocomplete="username" value="<?php echo ( ! empty( $_POST['username'] ) ) ? esc_attr( wp_unslash( $_POST['username'] ) ) : ''; ?>" /><?php // @codingStandardsIgnoreLine ?>
 				</p>
 
 			<?php endif; ?>
 
 			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-				<label for="reg_email"><?php esc_html_e( 'Email address', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+				<label for="reg_email"><?php esc_html_e( 'Email address', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 				<input type="email" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="email" id="reg_email" autocomplete="email" value="<?php echo ( ! empty( $_POST['email'] ) ) ? esc_attr( wp_unslash( $_POST['email'] ) ) : ''; ?>" /><?php // @codingStandardsIgnoreLine ?>
 			</p>
 
 			<?php if ( 'no' === get_option( 'woocommerce_registration_generate_password' ) ) : ?>
 
 				<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
-					<label for="reg_password"><?php esc_html_e( 'Password', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+					<label for="reg_password"><?php esc_html_e( 'Password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 					<input type="password" class="woocommerce-Input woocommerce-Input--text input-text form-control" name="password" id="reg_password" autocomplete="new-password" />
 				</p>
 
 			<?php else : ?>
 
-				<p><?php esc_html_e( 'A password will be sent to your email address.', 'understrap' ); ?></p>
+				<p><?php esc_html_e( 'A password will be sent to your email address.', 'woocommerce' ); ?></p>
 
 			<?php endif; ?>
 
@@ -103,7 +103,7 @@ $col = 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ? 6 :
 
 			<p class="woocommerce-form-row form-row">
 				<?php wp_nonce_field( 'woocommerce-register', 'woocommerce-register-nonce' ); ?>
-				<button type="submit" class="woocommerce-form-register__submit btn btn-outline-primary" name="register" value="<?php esc_attr_e( 'Register', 'understrap' ); ?>"><?php esc_html_e( 'Register', 'understrap' ); ?></button>
+				<button type="submit" class="woocommerce-form-register__submit btn btn-outline-primary" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
 			</p>
 
 			<?php do_action( 'woocommerce_register_form_end' ); ?>
@@ -115,4 +115,4 @@ $col = 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ? 6 :
 </div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_customer_login_form' ); ?>
+<?php do_action( 'woocommerce_after_customer_login_form' );

--- a/woocommerce/myaccount/form-lost-password.php
+++ b/woocommerce/myaccount/form-lost-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.5.2
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -22,10 +22,10 @@ do_action( 'woocommerce_before_lost_password_form' );
 
 <form method="post" class="woocommerce-ResetPassword lost_reset_password">
 
-	<p><?php echo apply_filters( 'woocommerce_lost_password_message', esc_html__( 'Lost your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'understrap' ) ); ?></p><?php // @codingStandardsIgnoreLine ?>
+	<p><?php echo apply_filters( 'woocommerce_lost_password_message', esc_html__( 'Lost your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'woocommerce' ) ); ?></p><?php // @codingStandardsIgnoreLine ?>
 
 	<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
-		<label for="user_login"><?php esc_html_e( 'Username or email', 'understrap' ); ?></label>
+		<label for="user_login"><?php esc_html_e( 'Username or email', 'woocommerce' ); ?></label>
 		<input class="woocommerce-Input woocommerce-Input--text input-text form-control" type="text" name="user_login" id="user_login" autocomplete="username" />
 	</p>
 
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_lost_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="btn btn-outline-primary" value="<?php esc_attr_e( 'Reset password', 'understrap' ); ?>"><?php esc_html_e( 'Reset password', 'understrap' ); ?></button>
+		<button type="submit" class="btn btn-outline-primary" value="<?php esc_attr_e( 'Reset password', 'woocommerce' ); ?>"><?php esc_html_e( 'Reset password', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'lost_password', 'woocommerce-lost-password-nonce' ); ?>

--- a/woocommerce/myaccount/form-reset-password.php
+++ b/woocommerce/myaccount/form-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.5.5
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -22,14 +22,14 @@ do_action( 'woocommerce_before_reset_password_form' );
 
 <form method="post" class="woocommerce-ResetPassword lost_reset_password">
 
-	<p><?php echo apply_filters( 'woocommerce_reset_password_message', esc_html__( 'Enter a new password below.', 'understrap' ) ); ?></p><?php // @codingStandardsIgnoreLine ?>
+	<p><?php echo apply_filters( 'woocommerce_reset_password_message', esc_html__( 'Enter a new password below.', 'woocommerce' ) ); ?></p><?php // @codingStandardsIgnoreLine ?>
 
 	<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
-		<label for="password_1"><?php esc_html_e( 'New password', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="password_1"><?php esc_html_e( 'New password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="password" class="woocommerce-Input woocommerce-Input--text input-text" name="password_1" id="password_1" autocomplete="new-password" />
 	</p>
 	<p class="woocommerce-form-row woocommerce-form-row--last form-row form-row-last">
-		<label for="password_2"><?php esc_html_e( 'Re-enter new password', 'understrap' ); ?>&nbsp;<span class="required">*</span></label>
+		<label for="password_2"><?php esc_html_e( 'Re-enter new password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
 		<input type="password" class="woocommerce-Input woocommerce-Input--text input-text" name="password_2" id="password_2" autocomplete="new-password" />
 	</p>
 
@@ -42,7 +42,7 @@ do_action( 'woocommerce_before_reset_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="btn btn-outline-primary" value="<?php esc_attr_e( 'Save', 'understrap' ); ?>"><?php esc_html_e( 'Save', 'understrap' ); ?></button>
+		<button type="submit" class="btn btn-outline-primary" value="<?php esc_attr_e( 'Save', 'woocommerce' ); ?>"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'reset_password', 'woocommerce-reset-password-nonce' ); ?>

--- a/woocommerce/myaccount/my-address.php
+++ b/woocommerce/myaccount/my-address.php
@@ -11,14 +11,12 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 2.6.0
  */
+// Exit if accessed directly.
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
+defined( 'ABSPATH' ) || exit;
 
 $customer_id = get_current_user_id();
 
@@ -26,8 +24,8 @@ if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) {
 	$get_addresses = apply_filters(
 		'woocommerce_my_account_get_addresses',
 		array(
-			'billing'  => __( 'Billing address', 'understrap' ),
-			'shipping' => __( 'Shipping address', 'understrap' ),
+			'billing'  => __( 'Billing address', 'woocommerce' ),
+			'shipping' => __( 'Shipping address', 'woocommerce' ),
 		),
 		$customer_id
 	);
@@ -35,7 +33,7 @@ if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) {
 	$get_addresses = apply_filters(
 		'woocommerce_my_account_get_addresses',
 		array(
-			'billing' => __( 'Billing address', 'understrap' ),
+			'billing' => __( 'Billing address', 'woocommerce' ),
 		),
 		$customer_id
 	);
@@ -46,7 +44,7 @@ $col    = 1;
 ?>
 
 <p>
-	<?php echo apply_filters( 'woocommerce_my_account_my_address_description', esc_html__( 'The following addresses will be used on the checkout page by default.', 'understrap' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php echo apply_filters( 'woocommerce_my_account_my_address_description', esc_html__( 'The following addresses will be used on the checkout page by default.', 'woocommerce' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 </p>
 
 <?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) : ?>
@@ -58,12 +56,12 @@ $col    = 1;
 	<div class="u-column woocommerce-Address">
 		<header class="woocommerce-Address-title title">
 			<h3><?php echo esc_html( $address_title ); ?></h3>
-			<a href="<?php echo esc_url( wc_get_endpoint_url( 'edit-address', $name ) ); ?>" class="edit"><?php esc_html_e( 'Edit', 'understrap' ); ?></a>
+			<a href="<?php echo esc_url( wc_get_endpoint_url( 'edit-address', $name ) ); ?>" class="edit"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
 		</header>
 		<address>
 		<?php
 			$address = wc_get_account_formatted_address( $name );
-			echo $address ? wp_kses_post( $address ) : esc_html_e( 'You have not set up this type of address yet.', 'understrap' );
+			echo $address ? wp_kses_post( $address ) : esc_html_e( 'You have not set up this type of address yet.', 'woocommerce' );
 		?>
 		</address>
 	</div>

--- a/woocommerce/myaccount/my-orders.php
+++ b/woocommerce/myaccount/my-orders.php
@@ -92,4 +92,5 @@ if ( $customer_orders ) : ?>
 			<?php endforeach; ?>
 		</tbody>
 	</table>
-<?php endif;
+	<?php
+	endif;

--- a/woocommerce/myaccount/my-orders.php
+++ b/woocommerce/myaccount/my-orders.php
@@ -6,17 +6,15 @@
  * @deprecated 2.6.0 this template file is no longer used. My Account shortcode uses orders.php.
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $my_orders_columns = apply_filters(
 	'woocommerce_my_account_my_orders_columns',
 	array(
-		'order-number'  => esc_html__( 'Order', 'understrap' ),
-		'order-date'    => esc_html__( 'Date', 'understrap' ),
-		'order-status'  => esc_html__( 'Status', 'understrap' ),
-		'order-total'   => esc_html__( 'Total', 'understrap' ),
+		'order-number'  => esc_html__( 'Order', 'woocommerce' ),
+		'order-date'    => esc_html__( 'Date', 'woocommerce' ),
+		'order-status'  => esc_html__( 'Status', 'woocommerce' ),
+		'order-total'   => esc_html__( 'Total', 'woocommerce' ),
 		'order-actions' => '&nbsp;',
 	)
 );
@@ -36,7 +34,7 @@ $customer_orders = get_posts(
 
 if ( $customer_orders ) : ?>
 
-	<h2><?php echo apply_filters( 'woocommerce_my_account_my_orders_title', esc_html__( 'Recent orders', 'understrap' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h2>
+	<h2><?php echo apply_filters( 'woocommerce_my_account_my_orders_title', esc_html__( 'Recent orders', 'woocommerce' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h2>
 
 	<table class="shop_table shop_table_responsive my_account_orders table-hover table-striped">
 
@@ -62,7 +60,7 @@ if ( $customer_orders ) : ?>
 
 							<?php elseif ( 'order-number' === $column_id ) : ?>
 								<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>">
-									<?php echo _x( '#', 'hash before order number', 'understrap' ) . $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+									<?php echo _x( '#', 'hash before order number', 'woocommerce' ) . $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 								</a>
 
 							<?php elseif ( 'order-date' === $column_id ) : ?>
@@ -74,7 +72,7 @@ if ( $customer_orders ) : ?>
 							<?php elseif ( 'order-total' === $column_id ) : ?>
 								<?php
 								/* translators: 1: formatted order total 2: total order items */
-								printf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'understrap' ), $order->get_formatted_order_total(), $item_count ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								printf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'woocommerce' ), $order->get_formatted_order_total(), $item_count ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 								?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
@@ -94,5 +92,4 @@ if ( $customer_orders ) : ?>
 			<?php endforeach; ?>
 		</tbody>
 	</table>
-	<?php
-endif;
+<?php endif;

--- a/woocommerce/myaccount/navigation.php
+++ b/woocommerce/myaccount/navigation.php
@@ -13,7 +13,7 @@
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 2.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/woocommerce/myaccount/orders.php
+++ b/woocommerce/myaccount/orders.php
@@ -46,7 +46,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 							<?php elseif ( 'order-number' === $column_id ) : ?>
 								<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>">
-									<?php echo esc_html( _x( '#', 'hash before order number', 'understrap' ) . $order->get_order_number() ); ?>
+									<?php echo esc_html( _x( '#', 'hash before order number', 'woocommerce' ) . $order->get_order_number() ); ?>
 								</a>
 
 							<?php elseif ( 'order-date' === $column_id ) : ?>
@@ -58,7 +58,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 							<?php elseif ( 'order-total' === $column_id ) : ?>
 								<?php
 								/* translators: 1: formatted order total 2: total order items */
-								echo wp_kses_post( sprintf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'understrap' ), $order->get_formatted_order_total(), $item_count ) );
+								echo wp_kses_post( sprintf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'woocommerce' ), $order->get_formatted_order_total(), $item_count ) );
 								?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
@@ -98,11 +98,10 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 <?php else : ?>
 	<div class="woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="btn btn-outline-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go to the shop', 'understrap' ); ?>
+			<?php esc_html_e( 'Go to the shop', 'woocommerce' ); ?>
 		</a>
-		<?php esc_html_e( 'No order has been made yet.', 'understrap' ); ?>
+		<?php esc_html_e( 'No order has been made yet.', 'woocommerce' ); ?>
 	</div>
 <?php endif; ?>
 
-<?php
-do_action( 'woocommerce_after_account_orders', $has_orders );
+<?php do_action( 'woocommerce_after_account_orders', $has_orders );

--- a/woocommerce/myaccount/orders.php
+++ b/woocommerce/myaccount/orders.php
@@ -104,4 +104,5 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 	</div>
 <?php endif; ?>
 
-<?php do_action( 'woocommerce_after_account_orders', $has_orders );
+<?php
+do_action( 'woocommerce_after_account_orders', $has_orders );

--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -22,11 +22,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <form role="search" method="get" class="woocommerce-product-search" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<div class="input-group">
-		<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field form-control" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'understrap' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />	
-		<label class="sr-only" for="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'understrap' ); ?></label>
+		<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field form-control" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'woocommerce' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />	
+		<label class="sr-only" for="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'woocommerce' ); ?></label>
 		<input type="hidden" name="post_type" value="product" />
 		<div class="input-group-append">
-			<button class="btn btn-primary" type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'understrap' ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'understrap' ); ?></button>
+			<button class="btn btn-primary" type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'woocommerce' ); ?></button>
 	</div>
 	</div>
 </form>

--- a/woocommerce/single-product/add-to-cart/simple.php
+++ b/woocommerce/single-product/add-to-cart/simple.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/woocommerce/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -4,7 +4,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.1
+ * @version 3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
## Description
This commit updates out-of-date WooCommerce templates and fixes the template version numbers in several incorrectly versioned templates. It also restores WooCommerce translations to the WooCommerce language domain and updates several out-of-date translations from past theme commits. Corrected spelling and grammar issues in CHANGELOG.md

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have checked that there aren't other open Pull Requests for the same update/change.
- [X] My code follows the code style of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] \(Optional) My change requires a change to the translations.
- [X] `composer cs:check` has passed locally.
- [X] `composer lint:php` has passed locally.
- [ X I have read the **CONTRIBUTING** document.

## Further comments
Fixes #1218 
Fixes #1297 
Fixes #1145 
Fixes #1138 
Fixes #974 
Fixes #893 
