### PR TITLE
Add woocommerce as allowed textdomain in the phpcs config

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,7 +41,10 @@
 	-->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="understrap"/>
+			<property name="text_domain" type="array">
+				<element value="understrap"/>
+				<element value="woocommerce"/>
+			</property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds woocommerce to the array of as allowed textdomains in the phpcs config file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1303 replaced the textdomain understrap with woocommerce in WooCommerce templates. Not adding it to the phpcs config will result in 'Mismatched text domain' errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **CONTRIBUTING** document.

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
phpcs still complains about a missing line after the file comment in woocommerce\myaccount\my-address.php.
