### PR TITLE
Update resource licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ The `fullwidthpage.php` template has full width layout without a sidebar.
 
 Licenses & Credits
 =
-- Font Awesome: http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT)
+- Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, CSS: MIT)
 - Bootstrap: http://getbootstrap.com | https://github.com/twbs/bootstrap/blob/master/LICENSE (MIT)
 - WP Bootstrap Navwalker by Edward McIntyre & William Patton: https://github.com/wp-bootstrap/wp-bootstrap-navwalker (GNU GPLv3)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ The `fullwidthpage.php` template has full width layout without a sidebar.
 
 Licenses & Credits
 =
-- Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, CSS: MIT)
+- Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, (S)CSS: MIT)
 - Bootstrap: http://getbootstrap.com | https://github.com/twbs/bootstrap/blob/master/LICENSE (MIT)
 - WP Bootstrap Navwalker by Edward McIntyre & William Patton: https://github.com/wp-bootstrap/wp-bootstrap-navwalker (GNU GPLv3)

--- a/readme.txt
+++ b/readme.txt
@@ -216,6 +216,6 @@ The front-page slider is widget driven. Simply add more than one widget to widge
 
 Licenses & Credits
 =
-- Font Awesome: http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT)
+- Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, CSS: MIT)
 - Bootstrap: http://getbootstrap.com | https://github.com/twbs/bootstrap/blob/master/LICENSE (MIT)
 - WP Bootstrap Navwalker by Edward McIntyre & William Patton: https://github.com/wp-bootstrap/wp-bootstrap-navwalker (GNU GPLv3)

--- a/readme.txt
+++ b/readme.txt
@@ -216,6 +216,6 @@ The front-page slider is widget driven. Simply add more than one widget to widge
 
 Licenses & Credits
 =
-- Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, CSS: MIT)
+- Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, (S)CSS: MIT)
 - Bootstrap: http://getbootstrap.com | https://github.com/twbs/bootstrap/blob/master/LICENSE (MIT)
 - WP Bootstrap Navwalker by Edward McIntyre & William Patton: https://github.com/wp-bootstrap/wp-bootstrap-navwalker (GNU GPLv3)

--- a/style.css
+++ b/style.css
@@ -21,11 +21,9 @@ This theme, like WordPress, is licensed under the GPL.
 UnderStrap is based on Underscores https://underscores.me/, (C) 2012-2016 Automattic, Inc.
 
 Resource Licenses:
-Font Awesome: http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
-Bootstrap: https://getbootstrap.com | https://github.com/twbs/bootstrap/blob/master/LICENSE (Code licensed under MIT, documentation under CC BY 3.0.)
-and of course
-jQuery: https://jquery.org | (Code licensed under MIT)
-WP Bootstrap Navwalker by Edward McIntyre: https://github.com/twittem/wp-bootstrap-navwalker | GNU GPL
+Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, CSS: MIT License)
+Bootstrap: https://getbootstrap.com | https://github.com/twbs/bootstrap/blob/master/LICENSE (MIT)
+WP Bootstrap Navwalker by Edward McIntyre & William Patton: https://github.com/twittem/wp-bootstrap-navwalker (GNU GPLv3)
 */
 
 /*

--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@ This theme, like WordPress, is licensed under the GPL.
 UnderStrap is based on Underscores https://underscores.me/, (C) 2012-2016 Automattic, Inc.
 
 Resource Licenses:
-Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, CSS: MIT License)
+Font Awesome: https://fontawesome.com/v4.7/license/ (Font: SIL OFL 1.1, (S)CSS: MIT)
 Bootstrap: https://getbootstrap.com | https://github.com/twbs/bootstrap/blob/master/LICENSE (MIT)
 WP Bootstrap Navwalker by Edward McIntyre & William Patton: https://github.com/twittem/wp-bootstrap-navwalker (GNU GPLv3)
 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR
- drops the reference to the jQuery license in style.css as jQuery is no longer shipped with Understrap,
- drops the reference to the Bootstrap documentation license as the documentation is not part of Understrap,
- fixes Font Awesome's license url, and
- makes WP Bootstrap Navwalker license info consistent across files 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resource licenses are outdated.
