### PR TITLE
[WIP] Make strings in editor.php translatable and remove the blockquote button

### DIFF
--- a/inc/editor.php
+++ b/inc/editor.php
@@ -83,3 +83,27 @@ if ( ! function_exists( 'understrap_tiny_mce_before_init' ) ) {
 		return $settings;
 	}
 }
+
+add_filter( 'mce_buttons', 'understrap_tiny_mce_blockquote_button' );
+
+if ( ! function_exists( 'understrap_tiny_mce_blockquote_button' ) ) {
+	/**
+	 * Removes the blockquote button from the TinyMCE toolbar.
+	 *
+	 * We provide the blockquote via the style formats. Using the style formats
+	 * blockquote receives the proper Bootstrap classes.
+	 *
+	 * @see understrap_tiny_mce_before_init()
+	 *
+	 * @param array $buttons TinyMCE buttons array.
+	 * @return array TinyMCE buttons array without the blockquote button.
+	 */
+	function understrap_tiny_mce_blockquote_button( $buttons ) {
+		foreach ( $buttons as $key => $button ) {
+			if ( 'blockquote' === $button ) {
+				unset( $buttons[ $key ] );
+			}
+		}
+		return $buttons;
+	}
+}

--- a/inc/editor.php
+++ b/inc/editor.php
@@ -47,29 +47,29 @@ if ( ! function_exists( 'understrap_tiny_mce_before_init' ) ) {
 
 		$style_formats = array(
 			array(
-				'title'    => 'Lead Paragraph',
+				'title'    => __( 'Lead Paragraph', 'understrap' ),
 				'selector' => 'p',
 				'classes'  => 'lead',
 				'wrapper'  => true,
 			),
 			array(
-				'title'  => 'Small',
+				'title'  => _x( 'Small', 'Font size name', 'understrap' ),
 				'inline' => 'small',
 			),
 			array(
-				'title'   => 'Blockquote',
+				'title'   => __( 'Blockquote', 'understrap' ),
 				'block'   => 'blockquote',
 				'classes' => 'blockquote',
 				'wrapper' => true,
 			),
 			array(
-				'title'   => 'Blockquote Footer',
+				'title'   => __( 'Blockquote Footer', 'understrap' ),
 				'block'   => 'footer',
 				'classes' => 'blockquote-footer',
 				'wrapper' => true,
 			),
 			array(
-				'title'  => 'Cite',
+				'title'  => __( 'Cite', 'understrap' ),
 				'inline' => 'cite',
 			),
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR
- makes the title of the style formats translatable. Translations will be added in #1337. 
- removes the blockquote button from the TinyMCE toolbar.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The titles which are displayed to the user are not translatable but should be.
- Using the default button the `<blockquote>` element does not receive the class `.blockquote` so it's better to hide it. A `<blockquote>` element with proper Bootstrap class can be inserted using the style formats dropwdown. Affects people using the classic editor or classic editor block only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
Providing non-translatable strings is a bug, I guess.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [x] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **CONTRIBUTING** document.
