### PR TITLE
adds dist-build and dist-clean tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "understrap",
-  "version": "1.0.0beta",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3769,7 +3769,7 @@
       }
     },
     "postcss-understrap-palette-generator": {
-      "version": "git+https://github.com/bacoords/postcss-understrap-palette-generator.git#33737b91a1c7408d1089e0ed1f74e522201bfc94",
+      "version": "git+https://github.com/bacoords/postcss-understrap-palette-generator.git#68694a2ae771a2610c66fc067452e61ae438edd2",
       "from": "git+https://github.com/bacoords/postcss-understrap-palette-generator.git",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "watch-run-css": "nodemon --watch sass/ --ext scss --exec \"npm-run-all css\"",
     "watch-run-js": "nodemon --watch src/js/ --ext js --exec \"npm-run-all js\"",
     "copy-assets": "node src/build/copy-assets.js",
-    "dist": "npm-run-all --parallel css js"
+    "dist": "npm-run-all --parallel css js",
+    "dist-build": "node src/build/dist-build.js",
+    "dist-clean": "node src/build/dist-clean.js"
   },
   "engines": {
     "node": "^12 || >=14"

--- a/src/build/dist-build.js
+++ b/src/build/dist-build.js
@@ -1,0 +1,40 @@
+const { promises: fs } = require("fs")
+const path = require("path")
+
+async function copyDir(src, dest) {
+    await fs.mkdir(dest, { recursive: true });
+    let entries = await fs.readdir(src, { withFileTypes: true });
+	let ignore = [
+		'node_modules',
+		'dist',
+		'src',
+		'.github',
+		'.browserslistrc',
+		'.editorconfig',
+		'.gitattributes',
+		'.gitignore',
+		'.jscsrc',
+		'.jshintignore',
+		'.travis.yml',
+		'composer.json',
+		'composer.lock',
+		'package.json',
+		'package-lock.json',
+		'phpcs.xml.dist',
+		'readme.txt'
+	];
+
+    for (let entry of entries) {
+		if ( ignore.indexOf( entry.name ) != -1 ) {
+			continue;
+		}
+        let srcPath = path.join(src, entry.name);
+        let destPath = path.join(dest, entry.name);
+
+        entry.isDirectory() ?
+            await copyDir(srcPath, destPath) :
+            await fs.copyFile(srcPath, destPath);
+    }
+}
+
+copyDir('./', './dist');

--- a/src/build/dist-clean.js
+++ b/src/build/dist-clean.js
@@ -1,0 +1,15 @@
+const del = require('del');
+
+// directory path
+const dir = './dist';
+
+// delete directory recursively
+(async () => {
+    try {
+        await del(dir);
+
+        console.log(`${dir} is deleted!`);
+    } catch (err) {
+        console.error(`Error while deleting ${dir}.`);
+    }
+})();


### PR DESCRIPTION
Adds two new npm commands `npm run dist-build` and `npm run dist-clean`. The first will build the `dist/` folder with a copy of the theme with NO build assets, package files, etc. The second deletes it. 


https://github.com/understrap/understrap/issues/1431