### PR TITLE
Bring back themejs folder watch

### DIFF
--- a/src/build/rollup.config.js
+++ b/src/build/rollup.config.js
@@ -25,7 +25,7 @@ const globals = {
 
 
 module.exports = {
-  input: [path.resolve(__dirname, '../js/bootstrap.js'), path.resolve(__dirname, '../js/skip-link-focus-fix.js'), path.resolve(__dirname, '../js/custom-javascript.js')],
+  input: [path.resolve(__dirname, '../js/bootstrap.js'), path.resolve(__dirname, '../js/skip-link-focus-fix.js'), path.resolve(__dirname, '../js/custom-javascript.js'), path.resolve(__dirname, '../js/themejs/*.js')],
   output: {
     banner,
     file: path.resolve(__dirname, `../../js/${fileDest}`),


### PR DESCRIPTION
Earlier version had gulp task watch themejs folder for js files, now that functionality is gone.

This feature is very useful because it allowed putting any library in a separate .js file in that folder, and keep custom-javascript.js for custom scripts.