### PR TITLE
Support Script Debug

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -23,7 +23,7 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 		$theme_styles  = "/css/theme{$suffix}.css";
 		$theme_scripts = "/js/theme{$suffix}.js";
 		if ( 'bootstrap4' === $bootstrap_version ) {
-			$theme_styles  = "/css/theme-bootstrap4{$suffix}.cs";
+			$theme_styles  = "/css/theme-bootstrap4{$suffix}.css";
 			$theme_scripts = "/js/theme-bootstrap4{$suffix}.js";
 		}
 

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -17,13 +17,14 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 		$the_theme         = wp_get_theme();
 		$theme_version     = $the_theme->get( 'Version' );
 		$bootstrap_version = get_theme_mod( 'understrap_bootstrap_version', 'bootstrap4' );
+		$suffix            = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		// Grab asset urls.
-		$theme_styles  = '/css/theme.min.css';
-		$theme_scripts = '/js/theme.min.js';
+		$theme_styles  = "/css/theme{$suffix}.css";
+		$theme_scripts = "/js/theme{$suffix}.js";
 		if ( 'bootstrap4' === $bootstrap_version ) {
-			$theme_styles  = '/css/theme-bootstrap4.min.css';
-			$theme_scripts = '/js/theme-bootstrap4.min.js';
+			$theme_styles  = "/css/theme-bootstrap4{$suffix}.cs";
+			$theme_scripts = "/js/theme-bootstrap4{$suffix}.js";
 		}
 
 		$css_version = $theme_version . '.' . filemtime( get_template_directory() . $theme_styles );


### PR DESCRIPTION
## Description
Understrap is already including the unminified version of assets.
These can be useful when debugging locally, or if minification is happening elsewhere in the stack.

WordPress uses the SCRIPT_DEBUG constant to tell core not to minify assets.
This PR brings that logic to understrap

## Motivation and Context
Fixes #1456 which has more context on why this is needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I pulled my branch from `develop`.
- [ ] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [ ] `composer cs:check` has passed locally.
- [ ] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

I pulled from Feature Bootstrap 5, but looks like I should have pulled from develop my thought was this could be released along side the Bootstrap 5 launch and it made sense to do the work now instead of doing it again when that release happens.

