### PR TITLE
adds semantic html for header/footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -15,7 +15,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 <?php get_template_part( 'sidebar-templates/sidebar', 'footerfull' ); ?>
 
-<div class="wrapper" id="wrapper-footer">
+<footer class="wrapper" id="wrapper-footer">
 
 	<div class="<?php echo esc_attr( $container ); ?>">
 
@@ -39,7 +39,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 	</div><!-- container end -->
 
-</div><!-- wrapper end -->
+</footer><!-- wrapper end -->
 
 </div><!-- #page we need this extra closing tag here -->
 

--- a/header.php
+++ b/header.php
@@ -27,10 +27,10 @@ $navbar_type       = get_theme_mod( 'understrap_navbar_type', 'collapse' );
 <div class="site" id="page">
 
 	<!-- ******************* The Navbar Area ******************* -->
-	<div id="wrapper-navbar">
+	<header id="wrapper-navbar">
 
 		<a class="skip-link sr-only sr-only-focusable" href="#content"><?php esc_html_e( 'Skip to content', 'understrap' ); ?></a>
 
 		<?php get_template_part( 'global-templates/navbar', $navbar_type . '-' . $bootstrap_version ); ?>
 
-	</div><!-- #wrapper-navbar end -->
+	</header><!-- #wrapper-navbar end -->


### PR DESCRIPTION
Updates the site's header and footer to be a `<header>` and `<footer>`, respectively. 

## Motivation and Context
https://github.com/understrap/understrap/discussions/1426
https://github.com/understrap/understrap/pull/1479#discussion_r736000160

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I pulled my branch from `develop`.
- [x ] I am submitting my pull request to `develop`.
- [x ] I have resolved any conflicts merging this pull request would create.
- [ x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x ] My code follows the code style of this project.
- [x ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [ ] `composer cs:check` has passed locally.
- [ ] `composer lint:php` has passed locally.
- [ x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

