### PR TITLE
Only enqueue jQuery if Bootstrap version = 4

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -30,7 +30,9 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 		$css_version = $theme_version . '.' . filemtime( get_template_directory() . $theme_styles );
 		wp_enqueue_style( 'understrap-styles', get_template_directory_uri() . $theme_styles, array(), $css_version );
 
-		wp_enqueue_script( 'jquery' );
+		if ( 'bootstrap4' === $bootstrap_version ) {
+			wp_enqueue_script( 'jquery' );
+		}
 
 		$js_version = $theme_version . '.' . filemtime( get_template_directory() . $theme_scripts );
 		wp_enqueue_script( 'understrap-scripts', get_template_directory_uri() . $theme_scripts, array(), $js_version, true );


### PR DESCRIPTION
## Description
Only enqueue jQuery if Bootstrap version = 4

## Motivation and Context
Bootstrap 5 no longer requires jQuery. This change only enqueues jQuery, if Bootstrap 4 is selected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.
