### PR TITLE
Remove listbox role from carousel

### DIFF
--- a/sidebar-templates/sidebar-hero.php
+++ b/sidebar-templates/sidebar-hero.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<div id="carouselExampleControls" class="carousel slide" data-ride="carousel" data-bs-ride="carousel" data-interval="false" data-bs-interval="false">
 
-		<div class="carousel-inner" role="listbox">
+		<div class="carousel-inner">
 
 			<?php dynamic_sidebar( 'hero' ); ?>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the role "listbox" from the `.carousel-inner` container.

## Motivation and Context
See https://github.com/twbs/bootstrap/issues/22061.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
I am far from being an expert when it comes to accessibility but given the information in the [W3C WAI tutorial on carousels](https://www.w3.org/WAI/tutorials/carousels/), I would guess that the carousel is not accessible.