### PR TITLE
Refactor understrap_entry_footer()

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -55,25 +55,67 @@ if ( ! function_exists( 'understrap_entry_footer' ) ) {
 	function understrap_entry_footer() {
 		// Hide category and tag text for pages.
 		if ( 'post' === get_post_type() ) {
-			/* translators: used between list items, there is a space after the comma */
-			$categories_list = get_the_category_list( esc_html__( ', ', 'understrap' ) );
-			if ( $categories_list && understrap_categorized_blog() ) {
-				/* translators: %s: Categories of current post */
-				printf( '<span class="cat-links">' . esc_html__( 'Posted in %s', 'understrap' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
-			/* translators: used between list items, there is a space after the comma */
-			$tags_list = get_the_tag_list( '', esc_html__( ', ', 'understrap' ) );
-			if ( $tags_list ) {
-				/* translators: %s: Tags of current post */
-				printf( '<span class="tags-links">' . esc_html__( 'Tagged %s', 'understrap' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
+			understrap_categories_tags_list();
 		}
-		if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
-			echo '<span class="comments-link">';
-			comments_popup_link( esc_html__( 'Leave a comment', 'understrap' ), esc_html__( '1 Comment', 'understrap' ), esc_html__( '% Comments', 'understrap' ) );
-			echo '</span>';
-		}
+		understrap_comments_popup_link();
 		understrap_edit_post_link();
+	}
+}
+
+if ( ! function_exists( 'understrap_categories_tags_list' ) ) {
+	/**
+	 * Displays a list of categories and a list of tags.
+	 */
+	function understrap_categories_tags_list() {
+		understrap_categories_list();
+		understrap_tags_list();
+	}
+}
+
+if ( ! function_exists( 'understrap_categories_list' ) ) {
+	/**
+	 * Displays a list of categories.
+	 */
+	function understrap_categories_list() {
+		/* translators: used between list items, there is a space after the comma */
+		$categories_list = get_the_category_list( esc_html__( ', ', 'understrap' ) );
+		if ( $categories_list && understrap_categorized_blog() ) {
+			/* translators: %s: Categories of current post */
+			printf( '<span class="cat-links">' . esc_html__( 'Posted in %s', 'understrap' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+	}
+}
+
+if ( ! function_exists( 'understrap_tags_list' ) ) {
+	/**
+	 * Displays a list of tags.
+	 */
+	function understrap_tags_list() {
+		/* translators: used between list items, there is a space after the comma */
+		$tags_list = get_the_tag_list( '', esc_html__( ', ', 'understrap' ) );
+		if ( $tags_list && ! is_wp_error( $tags_list ) ) {
+			/* translators: %s: Tags of current post */
+			printf( '<span class="tags-links">' . esc_html__( 'Tagged %s', 'understrap' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+	}
+}
+
+if ( ! function_exists( 'understrap_comments_popup_link' ) ) {
+	/**
+	 * Displays the link to the comments for the current post.
+	 */
+	function understrap_comments_popup_link() {
+		if ( is_single() || post_password_required() && ! ( comments_open() || get_comments_number() ) ) {
+			return;
+		}
+
+		echo '<span class="comments-link">';
+		comments_popup_link(
+			esc_html__( 'Leave a comment', 'understrap' ),
+			esc_html__( '1 Comment', 'understrap' ),
+			esc_html__( '% Comments', 'understrap' )
+		);
+		echo '</span>';
 	}
 }
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -105,7 +105,7 @@ if ( ! function_exists( 'understrap_comments_popup_link' ) ) {
 	 * Displays the link to the comments for the current post.
 	 */
 	function understrap_comments_popup_link() {
-		if ( is_single() || post_password_required() && ! ( comments_open() || get_comments_number() ) ) {
+		if ( is_single() || post_password_required() || ! comments_open() || 0 === absint( get_comments_number() ) ) {
 			return;
 		}
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -45,3 +45,7 @@ parameters:
 		- '#Function understrap_woocommerce_wrapper_end\(\) has no return type specified.#'
 		- '#Function understrap_wpcom_setup\(\) has no return type specified.#'
 		- '#Function understrap_wpcom_styles\(\) has no return type specified.#'
+		- '#Function understrap_categories_tags_list\(\) has no return type specified.#'
+		- '#Function understrap_categories_list\(\) has no return type specified.#'
+		- '#Function understrap_tags_list\(\) has no return type specified.#'
+		- '#Function understrap_comments_popup_link\(\) has no return type specified.#'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR refactors `understrap_entry_footer()` in order to
* reduce complexity

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of these.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
