### PR TITLE
Rename understrap_theme_slug_sanitize_select()

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -195,7 +195,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 } // End of if function_exists( 'understrap_theme_customize_register' ).
 add_action( 'customize_register', 'understrap_theme_customize_register' );
 
-if ( ! function_exists( 'understrap_theme_slug_sanitize_select' ) ) {
+if ( ! function_exists( 'understrap_customize_sanitize_select' ) ) {
 	/**
 	 * Sanitize select.
 	 *
@@ -204,7 +204,7 @@ if ( ! function_exists( 'understrap_theme_slug_sanitize_select' ) ) {
 	 * @return string|bool Sanitized slug if it is a valid choice; the setting default for
 	 *                     invalid choices and false in all other cases.
 	 */
-	function understrap_theme_slug_sanitize_select( $input, $setting ) {
+	function understrap_customize_sanitize_select( $input, $setting ) {
 
 		// Ensure input is a slug (lowercase alphanumeric characters, dashes and underscores are allowed only).
 		$input = sanitize_key( $input );

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -8,6 +8,25 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'understrap_theme_slug_sanitize_select' ) ) {
+	/**
+	 * Sanitize select.
+	 *
+	 * @param string               $input   Slug to sanitize.
+	 * @param WP_Customize_Setting $setting Setting instance.
+	 * @return string|bool Sanitized slug if it is a valid choice; the setting default for
+	 *                     invalid choices and false in all other cases.
+	 */
+	function understrap_theme_slug_sanitize_select( $input, $setting ) {
+		_deprecated_function(
+			'understrap_theme_slug_sanitize_select',
+			'1.2.0',
+			'understrap_customize_sanitize_select'
+		);
+		return understrap_customize_sanitize_select( $input, $setting );
+	}
+}
+
 if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
 	/**
 	 * Setup body classes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR renames `understrap_theme_slug_sanitize_select()` to `understrap_customize_sanitize_select()` to
* remove the `theme_slug` part which I guess was a copy'n'paste error,
* indicate that the function sanitizes the choices of a Customizer select element.

The PR assumes 1.2.0 to be the next release version.

## Motivation and Context
To use a more accurate function name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of these.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
