### PR TITLE
Fix 'Trying to access array offset on value of type bool' in WP 5.0-5.2

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'understrap_setup' ) ) {
 		/*
 		 * Adding Thumbnail basic support
 		 */
-		add_theme_support( 'post-thumbnails' );
+		add_theme_support( 'post-thumbnails', true );
 
 		/*
 		 * Adding support for Widget edit icons in customizer


### PR DESCRIPTION
## Description
This PR adds `true` as the second argument to `add_theme_support( 'post-thumbails' )`.

## Motivation and Context
Prior to version 5.3 calling `add_theme_support( 'post-thumbails' )` without the second argument makes WP try to access the index of a variable with value `true`. PHP throws a 'Trying to access array offset on value of type bool' notice. As Understrap currently supports WP versions back to version 5.0 we should fix this.

See https://github.com/WordPress/WordPress/blob/d1e96dfce29333740f8a5042e2e760746ede89ea/wp-includes/theme.php#L2340-L2362 (WP 5.2.15) for the code causing the notice and see https://github.com/WordPress/WordPress/blob/6d40400756c0dc14c7f9aac1e60f6a84fc428b3d/wp-includes/theme.php#L2385-L2405 (WP 5.3) for the code fixing the notice.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
