### PR TITLE
Replace understrap_kses_title() with wp_kses_post()

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -8,6 +8,35 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'understrap_kses_title' ) ) {
+	/*
+	 * Throw a deprecation notice if the function is not defined but used by
+	 * the child theme.
+     */
+
+	/**
+	 * Sanitizes data for allowed HTML tags for post title.
+	 *
+	 * @param string $data Post title to filter.
+	 * @return string Filtered post title with allowed HTML tags and attributes intact.
+	 *
+	 * @deprecated 1.2.0 Replaced with `wp_kses_post()`.
+	 */
+	function understrap_kses_title( $data ) {
+
+		_deprecated_function( 'understrap_kses_title', '1.2.0' );
+
+		global $allowedposttags;
+		if ( is_array( $allowedposttags ) ) {
+			$allowed_tags = apply_filters_deprecated( 'understrap_kses_title', $allowedposttags, '1.2.0' );
+			return wp_kses( $data, $allowed_tags );
+		}
+
+
+		return wp_kses_post( $data );
+	}
+} // End of if function_exists( 'understrap_kses_title' ).
+
 if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
 	/**
 	 * Setup body classes.

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'understrap_kses_title' ) ) {
 	/*
 	 * Throw a deprecation notice if the function is not defined but used by
 	 * the child theme.
-     */
+	 */
 
 	/**
 	 * Sanitizes data for allowed HTML tags for post title.

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -145,94 +145,18 @@ if ( ! function_exists( 'understrap_escape_the_archive_description' ) ) {
 	}
 } // End of if function_exists( 'understrap_escape_the_archive_description' ).
 
-// Escapes all occurances of 'the_title()' and 'get_the_title()'.
-add_filter( 'the_title', 'understrap_kses_title' );
+if ( function_exists( 'understrap_kses_title' ) ) {
+	_deprecated_function( 'understrap_kses_title', '1.2.0', 'wp_kses_post' );
 
-// Escapes all occurances of 'the_archive_title' and 'get_the_archive_title()'.
-add_filter( 'get_the_archive_title', 'understrap_kses_title' );
+	// Keep adding the filter for child themes that override understrap_kses_title().
+	add_filter( 'the_title', 'understrap_kses_title' );
+	add_filter( 'get_the_archive_title', 'understrap_kses_title' );
+} else {
+	// Escapes all occurances of 'the_title()' and 'get_the_title()'.
+	add_filter( 'the_title', 'wp_kses_post' );
 
-if ( ! function_exists( 'understrap_kses_title' ) ) {
-	/**
-	 * Sanitizes data for allowed HTML tags for post title.
-	 *
-	 * @param string $data Post title to filter.
-	 * @return string Filtered post title with allowed HTML tags and attributes intact.
-	 */
-	function understrap_kses_title( $data ) {
-		// Tags not supported in HTML5 are not allowed.
-		$allowed_tags = array(
-			'abbr'             => array(),
-			'aria-describedby' => true,
-			'aria-details'     => true,
-			'aria-label'       => true,
-			'aria-labelledby'  => true,
-			'aria-hidden'      => true,
-			'b'                => array(),
-			'bdo'              => array(
-				'dir' => true,
-			),
-			'blockquote'       => array(
-				'cite'     => true,
-				'lang'     => true,
-				'xml:lang' => true,
-			),
-			'cite'             => array(
-				'dir'  => true,
-				'lang' => true,
-			),
-			'dfn'              => array(),
-			'em'               => array(),
-			'i'                => array(
-				'aria-describedby' => true,
-				'aria-details'     => true,
-				'aria-label'       => true,
-				'aria-labelledby'  => true,
-				'aria-hidden'      => true,
-				'class'            => true,
-			),
-			'code'             => array(),
-			'del'              => array(
-				'datetime' => true,
-			),
-			'img'              => array(
-				'src'    => true,
-				'alt'    => true,
-				'width'  => true,
-				'height' => true,
-				'class'  => true,
-				'style'  => true,
-			),
-			'ins'              => array(
-				'datetime' => true,
-				'cite'     => true,
-			),
-			'kbd'              => array(),
-			'mark'             => array(),
-			'pre'              => array(
-				'width' => true,
-			),
-			'q'                => array(
-				'cite' => true,
-			),
-			's'                => array(),
-			'samp'             => array(),
-			'span'             => array(
-				'dir'      => true,
-				'align'    => true,
-				'lang'     => true,
-				'xml:lang' => true,
-			),
-			'small'            => array(),
-			'strong'           => array(),
-			'sub'              => array(),
-			'sup'              => array(),
-			'u'                => array(),
-			'var'              => array(),
-		);
-		$allowed_tags = apply_filters( 'understrap_kses_title', $allowed_tags );
-
-		return wp_kses( $data, $allowed_tags );
-	}
+	// Escapes all occurances of 'the_archive_title' and 'get_the_archive_title()'.
+	add_filter( 'get_the_archive_title', 'wp_kses_post' );
 } // End of if function_exists( 'understrap_kses_title' ).
 
 if ( ! function_exists( 'understrap_hide_posted_by' ) ) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,6 +66,11 @@ parameters:
 			path: inc/extras.php
 
 		-
+			message: "#^Parameter \\#2 \\$callback of function add_filter expects callable\\(\\)\\: mixed, 'understrap_kses…' given\\.$#"
+			count: 2
+			path: inc/extras.php
+
+		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|string\\|false given\\.$#"
 			count: 2
 			path: inc/hooks.php


### PR DESCRIPTION
## Description
This PR deprecates the `understrap_kses_title()` filter and replaces it with `wp_kses_post()`.

## Motivation and Context
`understrap_kses_title()` causes issues by aggressively stripping HTML from titles. To escape titles with `wp_kses_post()` is less strict but still strips scripts from titles.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests
#1305
#1468
#1648
#1849 

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
