### PR TITLE
Update class-wp-bootstrap-navwalker.php

### DIFF
--- a/inc/class-wp-bootstrap-navwalker.php
+++ b/inc/class-wp-bootstrap-navwalker.php
@@ -182,10 +182,12 @@ if ( ! class_exists( 'Understrap_WP_Bootstrap_Navwalker' ) ) {
 			}
 
 			$atts['target'] = ! empty( $item->target ) ? $item->target : '';
-			if ( '_blank' === $item->target && empty( $item->xfn ) ) { // Thanks to LukaszJaro, see https://github.com/understrap/understrap/issues/973.
+			if ( property_exists( $item, 'target' ) && '_blank' === $item->target && empty( $item->xfn ) ) { // Thanks to LukaszJaro, see https://github.com/understrap/understrap/issues/973.
 				$atts['rel'] = 'noopener noreferrer';
 			} else {
-				$atts['rel'] = $item->xfn;
+			    if ( property_exists( $item, 'xfn' ) ) {
+			        $atts['rel'] = $item->xfn;
+			    }
 			}
 
 			// If item has_children add atts to <a>.


### PR DESCRIPTION
## Description
Was getting the following errors from Query monitor while using the Understrap parent theme;

Notice - Undefined property: stdClass::$target - 10 - wp-content/themes/understrap/inc/class-wp-bootstrap-navwalker.php:185 - Parent Theme
Notice - Undefined property: stdClass::$xfn - 10 - wp-content/themes/understrap/inc/class-wp-bootstrap-navwalker.php:189 - Parent Theme

## Motivation and Context
These fix the 20 PHP Notices that I was getting and maybe should do for other people.

## Types of changes
Added two checks for these two properties to simply check they exist before they are called.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Further comments
I hope I pulled correctly for this, sorry if I didn't
