### PR TITLE
Re-fix #1841

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'understrap_setup' ) ) {
 		/*
 		 * Adding Thumbnail basic support
 		 */
-		add_theme_support( 'post-thumbnails', true );
+		add_theme_support( 'post-thumbnails', array() );
 
 		/*
 		 * Adding support for Widget edit icons in customizer


### PR DESCRIPTION
## Description
This PR uses `array()` instead of `true` as the second argument for `add_theme_support( 'post-thumbnails' )`.

## Motivation and Context
#1841 added the second argument `add_theme_support( 'post-thumbnails' )` to fix a PHP warning in WP < 5.3. Setting the argument to a boolean value (true) causes a PHP warning on the edit screen for posts and pages in WP > 5.2. Using  an empty array fixes the warning in WP < 5.3 and WP > 5.2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
Sorry for not noticing sooner.