### PR TITLE
Fix customizer preview

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -22,6 +22,11 @@ if ( ! function_exists( 'understrap_customize_register' ) ) {
 				$get_setting->transport = 'postMessage';
 			}
 		}
+
+		$custom_logo = $wp_customize->get_setting( 'custom_logo' );
+		if ( $custom_logo instanceof WP_Customize_Setting ) {
+			$custom_logo->transport = 'refresh';
+		}
 	}
 }
 add_action( 'customize_register', 'understrap_customize_register' );
@@ -191,6 +196,10 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 			)
 		);
 
+		$understrap_site_info = $wp_customize->get_setting( 'understrap_site_info_override' );
+		if ( $understrap_site_info instanceof WP_Customize_Setting ) {
+			$understrap_site_info->transport = 'postMessage';
+		}
 	}
 } // End of if function_exists( 'understrap_theme_customize_register' ).
 add_action( 'customize_register', 'understrap_theme_customize_register' );
@@ -231,11 +240,17 @@ if ( ! function_exists( 'understrap_customize_preview_js' ) ) {
 	 * Setup JS integration for live previewing.
 	 */
 	function understrap_customize_preview_js() {
+		$file    = '/js/customizer.js';
+		$version = filemtime( get_template_directory() . $file );
+		if ( false === $version ) {
+			$version = time();
+		}
+
 		wp_enqueue_script(
 			'understrap_customizer',
-			get_template_directory_uri() . '/js/customizer.js',
+			get_template_directory_uri() . $file,
 			array( 'customize-preview' ),
-			'20130508',
+			(string) $version,
 			true
 		);
 	}
@@ -250,11 +265,17 @@ if ( ! function_exists( 'understrap_customize_controls_js' ) ) {
 	 * Setup JS integration for live previewing.
 	 */
 	function understrap_customize_controls_js() {
+		$file    = '/js/customizer-controls.js';
+		$version = filemtime( get_template_directory() . $file );
+		if ( false === $version ) {
+			$version = time();
+		}
+
 		wp_enqueue_script(
 			'understrap_customizer',
-			get_template_directory_uri() . '/js/customizer-controls.js',
+			get_template_directory_uri() . $file,
 			array( 'customize-preview' ),
-			'20130508',
+			(string) $version,
 			true
 		);
 	}

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'understrap_customize_register' ) ) {
 	 * @param WP_Customize_Manager $wp_customize Customizer reference.
 	 */
 	function understrap_customize_register( $wp_customize ) {
-		$settings = array( 'blogname', 'blogdescription', 'header_textcolor' );
+		$settings = array( 'blogname', 'header_textcolor' );
 		foreach ( $settings as $setting ) {
 			$get_setting = $wp_customize->get_setting( $setting );
 			if ( $get_setting instanceof WP_Customize_Setting ) {

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 if ( ! function_exists( 'understrap_customize_register' ) ) {
 	/**
-	 * Register basic support (site title, description, header text color) for the Theme Customizer.
+	 * Register basic support (site title, header text color) for the Theme Customizer.
 	 *
 	 * @param WP_Customize_Manager $wp_customize Customizer reference.
 	 */
@@ -23,13 +23,34 @@ if ( ! function_exists( 'understrap_customize_register' ) ) {
 			}
 		}
 
-		$custom_logo = $wp_customize->get_setting( 'custom_logo' );
-		if ( $custom_logo instanceof WP_Customize_Setting ) {
-			$custom_logo->transport = 'refresh';
-		}
+		// Override default partial for custom logo.
+		$wp_customize->selective_refresh->add_partial(
+			'custom_logo',
+			array(
+				'settings'            => array( 'custom_logo' ),
+				'selector'            => '.custom-logo-link',
+				'render_callback'     => 'understrap_customize_partial_custom_logo',
+				'container_inclusive' => false,
+			)
+		);
 	}
 }
 add_action( 'customize_register', 'understrap_customize_register' );
+
+if ( ! function_exists( 'understrap_customize_partial_custom_logo' ) ) {
+	/**
+	 * Callback for rendering the custom logo, used in the custom_logo partial.
+	 *
+	 * @return string The custom logo markup or the site title.
+	 */
+	function understrap_customize_partial_custom_logo() {
+		if ( has_custom_logo() ) {
+			return get_custom_logo();
+		} else {
+			return get_bloginfo( 'name' );
+		}
+	}
+}
 
 if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 	/**

--- a/js/customizer-controls.js
+++ b/js/customizer-controls.js
@@ -5,22 +5,25 @@
  * when users open or close the front page sections section.
  */
 
- (function() {
-	wp.customize.bind( 'ready', function() {
+ ( function () {
+	wp.customize.bind( 'ready', function () {
 		// Only show the navbar type setting when running Bootstrap 5.
-		wp.customize( 'understrap_bootstrap_version', function( setting ) {
-			wp.customize.control( 'understrap_navbar_type', function( control ) {
-				var visibility = function() {
-					if ( 'bootstrap5' === setting.get() ) {
-						control.container.slideDown( 180 );
-					} else {
-						control.container.slideUp( 180 );
-					}
-				};
+		wp.customize( 'understrap_bootstrap_version', function ( setting ) {
+			wp.customize.control(
+				'understrap_navbar_type',
+				function ( control ) {
+					const visibility = function () {
+						if ( 'bootstrap5' === setting.get() ) {
+							control.container.slideDown( 180 );
+						} else {
+							control.container.slideUp( 180 );
+						}
+					};
 
-				visibility();
-				setting.bind( visibility );
-			});
-		});
-	});
-})();
+					visibility();
+					setting.bind( visibility );
+				}
+			);
+		} );
+	} );
+} )();

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -8,7 +8,6 @@
 
  ( function () {
 	let anchor = document.querySelector( '.navbar-brand' );
-	console.log(anchor.tagName);
 	if ( 'H1' === anchor.tagName ) {
 		anchor = anchor.firstChild;
 	}

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -1,42 +1,43 @@
 /**
- * File customizcustomizer.js.
+ * File: customizer.js.
  *
  * Theme Customizer enhancements for a better user experience.
  *
  * Contains handlers to make Theme Customizer preview reload changes asynchronously.
  */
 
-( function( $ ) {
+ ( function () {
+	let anchor = document.querySelector( '.navbar-brand' );
+	console.log(anchor.tagName);
+	if ( 'H1' === anchor.tagName ) {
+		anchor = anchor.firstChild;
+	}
 
-	// Site title and description.
-	wp.customize( 'blogname', function( value ) {
-		value.bind( function( to ) {
-			$( '.site-title a' ).text( to );
-		} );
-	} );
-	wp.customize( 'blogdescription', function( value ) {
-		value.bind( function( to ) {
-			$( '.site-description' ).text( to );
+	// Site title.
+	wp.customize( 'blogname', function ( value ) {
+		value.bind( function ( to ) {
+			anchor.textContent = to;
 		} );
 	} );
 
 	// Header text color.
-	wp.customize( 'header_textcolor', function( value ) {
-		value.bind( function( to ) {
+	wp.customize( 'header_textcolor', function ( value ) {
+		value.bind( function ( to ) {
 			if ( 'blank' === to ) {
-				$( '.site-title a, .site-description' ).css( {
-					'clip': 'rect(1px, 1px, 1px, 1px)',
-					'position': 'absolute'
-				} );
+				anchor.style.clip = 'rect(1px, 1px, 1px, 1px)';
+				anchor.style.position = 'absolute';
 			} else {
-				$( '.site-title a, .site-description' ).css( {
-					'clip': 'auto',
-					'position': 'relative'
-				} );
-				$( '.site-title a, .site-description' ).css( {
-					'color': to
-				} );
+				anchor.style.clip = 'auto';
+				anchor.style.position = 'relative';
+				anchor.style.color = to;
 			}
 		} );
 	} );
-} )( jQuery );
+
+	// Site info.
+	wp.customize( 'understrap_site_info_override', function ( value ) {
+		value.bind( function ( to ) {
+			document.querySelector( '.site-info' ).innerHTML = to;
+		} );
+	} );
+} )();


### PR DESCRIPTION
## Description
This PR 
* fixes the customizer preview for the site title which was not working at all.
* fixes the customizer preview for the custom logo as removing the logo did not trigger a reload of the site title.
* adds the 'postMessage' transport property for the site info to prevent page reloads and adds JS to handle the preview.
* removes the 'postMessage' transport property for blogdescription. Understrap does not use the tagline, so there is no need to provide JS for handling the preview.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [X] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.