### PR TITLE
Fix comments popup link not showing

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -120,7 +120,7 @@ if ( ! function_exists( 'understrap_comments_popup_link' ) ) {
 	 * Displays the link to the comments for the current post.
 	 */
 	function understrap_comments_popup_link() {
-		if ( is_single() || post_password_required() || ! comments_open() || 0 === absint( get_comments_number() ) ) {
+		if ( is_single() || post_password_required() || ( ! comments_open() && 0 === absint( get_comments_number() ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description
This PR fixes the early return condition in `understrap_comments_popup_link()`.

## Motivation and Context
The comments popup link does not display "Leave a comment" if comments are open but no comments have been left.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Bug has been introduced in #1831. It was never part of a release.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [X] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.
