### PR TITLE
Add understrap_get_list_item_separator()

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -92,8 +92,7 @@ if ( ! function_exists( 'understrap_categories_list' ) ) {
 	 * Displays a list of categories.
 	 */
 	function understrap_categories_list() {
-		/* translators: used between list items, there is a space after the comma */
-		$categories_list = get_the_category_list( esc_html__( ', ', 'understrap' ) );
+		$categories_list = get_the_category_list( understrap_get_list_item_separator() );
 		if ( $categories_list && understrap_categorized_blog() ) {
 			/* translators: %s: Categories of current post */
 			printf( '<span class="cat-links">' . esc_html__( 'Posted in %s', 'understrap' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -106,8 +105,7 @@ if ( ! function_exists( 'understrap_tags_list' ) ) {
 	 * Displays a list of tags.
 	 */
 	function understrap_tags_list() {
-		/* translators: used between list items, there is a space after the comma */
-		$tags_list = get_the_tag_list( '', esc_html__( ', ', 'understrap' ) );
+		$tags_list = get_the_tag_list( '', understrap_get_list_item_separator() );
 		if ( $tags_list && ! is_wp_error( $tags_list ) ) {
 			/* translators: %s: Tags of current post */
 			printf( '<span class="tags-links">' . esc_html__( 'Tagged %s', 'understrap' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -315,5 +313,23 @@ if ( ! function_exists( 'understrap_link_pages' ) ) {
 			)
 		);
 		wp_link_pages( $args );
+	}
+}
+
+if ( ! function_exists( 'understrap_get_list_item_separator' ) ) {
+	/**
+	 * Retrieves the localized list item separator.
+	 *
+	 * `wp_get_list_item_separator()` has been introduced in WP 6.0.0. For WP
+	 * versions lower than 6.0.0 we have to use a custom translation.
+	 *
+	 * @return string Localized list item separator.
+	 */
+	function understrap_get_list_item_separator() {
+		if ( function_exists( 'wp_get_list_item_separator' ) ) {
+			return esc_html( wp_get_list_item_separator() );
+		}
+		/* translators: used between list items, there is a space after the comma */
+		return esc_html__( ', ', 'understrap' );
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -75,6 +75,7 @@
 				<element value="get_the_title"/>
 				<element value="get_the_archive_title"/>
 				<element value="get_the_archive_description"/>
+				<element value="understrap_get_list_item_separator"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
## Description
This PR introduces the function `understrap_get_list_item_separator()` which retrieves the localized list item separator (", ").

## Motivation and Context
Since WP 6.0 there is a WP core translation for `__( ', ' )`  that can be retrieved using [`wp_get_list_item_separator()`](https://developer.wordpress.org/reference/functions/wp_get_list_item_separator/). `understrap_get_list_item_separator()` returns the WP core translation if `wp_get_list_item_separator()` exists and the Understrap translation if the core translation does not exist. People on WP >= 6.0 benefit from the WP core translation which is available in many more languages than the Understrap translation.

`understrap_get_list_item_separator()` can be removed once Understrap drops support for WP < 6.0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.
