### PR TITLE
Fix flushing category transient

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -165,8 +165,10 @@ if ( ! function_exists( 'understrap_categorized_blog' ) ) {
 	}
 }
 
-add_action( 'edit_category', 'understrap_category_transient_flusher' );
+add_action( 'delete_category', 'understrap_category_transient_flusher' );
 add_action( 'save_post', 'understrap_category_transient_flusher' );
+add_action( 'trashed_post', 'understrap_category_transient_flusher' );
+add_action( 'deleted_post', 'understrap_category_transient_flusher' );
 
 if ( ! function_exists( 'understrap_category_transient_flusher' ) ) {
 	/**


### PR DESCRIPTION
## Description
This PR 
* adds `understrap_category_transient_flusher` to the `trashed_post` and `deleted_post` action hooks and
* removes `understrap_category_transient_flusher()` from the `edit_taxonomy` hook.

## Motivation and Context
By flushing the corresponding transient `understrap_category_transient_flusher()` forces  `understrap_categorized_blog()` to regenerate the transient. The number of categories (for numbers >= 2 it is a categorized blog) may change if
* a post is saved/updated,
* a post is trashed,
* a post is deleted (and trash is disabled),
* a category is deleted.

In those cases the transient should be flushed.

The number of categories does not change if you edit a category. The transient does not need to be regenerated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Further comments
Does the number of categories change in any other case?