### PR TITLE
Remove obsolete PHP_CodeSniffer ignore comments

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -33,13 +33,13 @@ if ( ! function_exists( 'understrap_add_site_info' ) ) {
 				esc_html__( 'Proudly powered by %s', 'understrap' ),
 				'WordPress'
 			),
-			sprintf( // WPCS: XSS ok.
+			sprintf(
 				/* translators: 1: Theme name, 2: Theme author */
 				esc_html__( 'Theme: %1$s by %2$s.', 'understrap' ),
 				$the_theme->get( 'Name' ),
 				'<a href="' . esc_url( __( 'https://understrap.com', 'understrap' ) ) . '">understrap.com</a>'
 			),
-			sprintf( // WPCS: XSS ok.
+			sprintf(
 				/* translators: Theme version */
 				esc_html__( 'Version: %1$s', 'understrap' ),
 				$the_theme->get( 'Version' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes two outdated and obsolete PHP_CodeSniffer ignore comments ("WPCS: XSS ok.").

## Motivation and Context
The comments are no longer needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
