### PR TITLE
Update footer widget role to "complementary"

### DIFF
--- a/sidebar-templates/sidebar-footerfull.php
+++ b/sidebar-templates/sidebar-footerfull.php
@@ -16,7 +16,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 	<!-- ******************* The Footer Full-width Widget Area ******************* -->
 
-	<div class="wrapper" id="wrapper-footer-full" role="footer">
+	<div class="wrapper" id="wrapper-footer-full" role="complementary">
 
 		<div class="<?php echo esc_attr( $container ); ?>" id="footer-full-content" tabindex="-1">
 


### PR DESCRIPTION
Fix for issue with `role="footer"` in lighthouse. Updates the role to "complementary" (also considering changing the element to an aside, but that could be more of a breaking change).

Closes #1775