### PR TITLE
Use strict comparison for in_array

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -169,8 +169,8 @@ if ( ! function_exists( 'understrap_kses_title' ) ) {
 		$allowed_tags      = wp_kses_allowed_html( 'post' );
 		$allowed_protocols = wp_allowed_protocols();
 		if (
-			in_array( 'polylang/polylang.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) )
-			|| in_array( 'polylang-pro/polylang.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) )
+			in_array( 'polylang/polylang.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true )
+			|| in_array( 'polylang-pro/polylang.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true )
 		) {
 			if ( ! in_array( 'data', $allowed_protocols, true ) ) {
 				$allowed_protocols[] = 'data';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to use strict comparison this PR adds the third argument to `in_array()`.

## Motivation and Context
Fixing WP coding standard warnings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.
