### PR TITLE
Fix widget name in function comment

### DIFF
--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -60,7 +60,7 @@ add_filter( 'wp_dropdown_cats', 'understrap_add_block_widget_categories_class', 
 
 if ( ! function_exists( 'understrap_add_block_widget_archives_classes' ) ) {
 	/**
-	 * Adds Bootstrap class to select tag in the Categories widget.
+	 * Adds Bootstrap class to select tag in the Archives widget.
 	 *
 	 * @param string $block_content The block content.
 	 * @param array  $block         The full block, including name and attributes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the widget name in the function comment for `understrap_add_block_widget_archives_classes()`.

## Motivation and Context
It is Categories instead of Archives.
