### PR TITLE
Fix understrap_adjust_body_class

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -38,7 +38,6 @@ if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
 	 */
 	function understrap_adjust_body_class( $classes ) {
 		_deprecated_function( 'understrap_adjust_body_class', '0.9.4' );
-		return $classes;
 	}
 }
 

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -38,6 +38,7 @@ if ( ! function_exists( 'understrap_adjust_body_class' ) ) {
 	 */
 	function understrap_adjust_body_class( $classes ) {
 		_deprecated_function( 'understrap_adjust_body_class', '0.9.4' );
+		return $classes;
 	}
 }
 


### PR DESCRIPTION
## Description
This PR lets `understrap_adjust_body_class()` return the unfiltered parameter `$classes`.

## Motivation and Context
Although this function has been deprecated in v0.9.4 it might break the body classes if a user with an older version using of Understrap `understrap_adjust_body_class()` upgrades to a newer version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

