### PR TITLE
Add since tag for changes from v1.0.0

### DIFF
--- a/global-templates/navbar-branding.php
+++ b/global-templates/navbar-branding.php
@@ -3,6 +3,7 @@
  * Navbar branding
  *
  * @package Understrap
+ * @since 1.2.0
  */
 
 // Exit if accessed directly.

--- a/global-templates/navbar-collapse-bootstrap4.php
+++ b/global-templates/navbar-collapse-bootstrap4.php
@@ -3,6 +3,7 @@
  * Header Navbar (bootstrap4)
  *
  * @package Understrap
+ * @since 1.1.0
  */
 
 // Exit if accessed directly.

--- a/global-templates/navbar-collapse-bootstrap5.php
+++ b/global-templates/navbar-collapse-bootstrap5.php
@@ -3,6 +3,7 @@
  * Header Navbar (bootstrap5)
  *
  * @package Understrap
+ * @since 1.1.0
  */
 
 // Exit if accessed directly.

--- a/global-templates/navbar-offcanvas-bootstrap5.php
+++ b/global-templates/navbar-offcanvas-bootstrap5.php
@@ -3,6 +3,7 @@
  * Header Navbar (bootstrap5)
  *
  * @package Understrap
+ * @since 1.1.0
  */
 
 // Exit if accessed directly.

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -3,6 +3,7 @@
  * Block editor (gutenberg) specific functionality
  *
  * @package Understrap
+ * @since 1.0.0
  */
 
 add_action( 'after_setup_theme', 'understrap_block_editor_setup' );
@@ -11,6 +12,8 @@ if ( ! function_exists( 'understrap_block_editor_setup' ) ) {
 
 	/**
 	 * Sets up our default theme support for the WordPress block editor.
+	 *
+	 * @since 1.0.0
 	 */
 	function understrap_block_editor_setup() {
 
@@ -31,6 +34,8 @@ if ( ! function_exists( 'understrap_block_editor_setup' ) ) {
 if ( ! function_exists( 'understrap_generate_color_palette' ) ) {
 	/**
 	 * Checks for our JSON file of color values. If exists, creates a color palette array.
+	 *
+	 * @since 1.0.0
 	 *
 	 * @return array
 	 */
@@ -59,6 +64,8 @@ if ( ! function_exists( 'understrap_generate_color_palette' ) ) {
 
 		/**
 		 * Filters the default bootstrap color palette so it can be overriden by child themes or plugins when we add theme support for editor-color-palette.
+		 *
+		 * @since 1.0.0
 		 *
 		 * @param array $color_palette An array of color options for the editor-color-palette setting.
 		 */

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -229,6 +229,8 @@ if ( ! function_exists( 'understrap_customize_sanitize_select' ) ) {
 	/**
 	 * Sanitize select.
 	 *
+	 * @since 1.2.0 Renamed from understrap_theme_slug_sanitize_select()
+	 *
 	 * @param string               $input   Slug to sanitize.
 	 * @param WP_Customize_Setting $setting Setting instance.
 	 * @return string|bool Sanitized slug if it is a valid choice; the setting default for
@@ -284,6 +286,8 @@ add_action( 'customize_preview_init', 'understrap_customize_preview_js' );
 if ( ! function_exists( 'understrap_customize_controls_js' ) ) {
 	/**
 	 * Setup JS integration for live previewing.
+	 *
+	 * @since 1.1.0
 	 */
 	function understrap_customize_controls_js() {
 		$file    = '/js/customizer-controls.js';
@@ -307,8 +311,10 @@ if ( ! function_exists( 'understrap_default_navbar_type' ) ) {
 	/**
 	 * Overrides the responsive navbar type for Bootstrap 4.
 	 *
+	 * @since 1.1.0
+	 *
 	 * @param string $current_mod Current navbar type.
-	 * @return string
+	 * @return string Maybe filtered navbar type.
 	 */
 	function understrap_default_navbar_type( $current_mod ) {
 

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -12,17 +12,18 @@ if ( ! function_exists( 'understrap_theme_slug_sanitize_select' ) ) {
 	/**
 	 * Sanitize select.
 	 *
+	 * @deprecated 1.2.0 Use understrap_customize_sanitize_select()
+	 * @see understrap_customize_sanitize_select()
+	 *
+	 * @since 0.6.11
+	 *
 	 * @param string               $input   Slug to sanitize.
 	 * @param WP_Customize_Setting $setting Setting instance.
 	 * @return string|bool Sanitized slug if it is a valid choice; the setting default for
 	 *                     invalid choices and false in all other cases.
 	 */
 	function understrap_theme_slug_sanitize_select( $input, $setting ) {
-		_deprecated_function(
-			'understrap_theme_slug_sanitize_select',
-			'1.2.0',
-			'understrap_customize_sanitize_select'
-		);
+		_deprecated_function( __FUNCTION__, '1.2.0', 'understrap_customize_sanitize_select' );
 		return understrap_customize_sanitize_select( $input, $setting );
 	}
 }

--- a/inc/editor.php
+++ b/inc/editor.php
@@ -95,6 +95,8 @@ if ( ! function_exists( 'understrap_tiny_mce_blockquote_button' ) ) {
 	 * We provide the blockquote via the style formats. Using the style formats
 	 * blockquote receives the proper Bootstrap classes.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @see understrap_tiny_mce_before_init()
 	 *
 	 * @param array $buttons TinyMCE buttons array.

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -52,6 +52,8 @@ if ( ! function_exists( 'understrap_offcanvas_admin_bar_inline_styles' ) ) {
 	 * Add inline styles for the offcanvas component if the admin bar is visibile.
 	 *
 	 * Fixes that the offcanvas close icon is hidden behind the admin bar.
+	 *
+	 * @since 1.2.0
 	 */
 	function understrap_offcanvas_admin_bar_inline_styles() {
 		$navbar_type = get_theme_mod( 'understrap_navbar_type', 'collapse' );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -194,6 +194,8 @@ if ( ! function_exists( 'understrap_hide_posted_by' ) ) {
 	/**
 	 * Hides the posted by markup in `understrap_posted_on()`.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @param string $byline Posted by HTML markup.
 	 * @return string Maybe filtered posted by HTML markup.
 	 */

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -80,6 +80,8 @@ if ( ! function_exists( 'understrap_entry_footer' ) ) {
 if ( ! function_exists( 'understrap_categories_tags_list' ) ) {
 	/**
 	 * Displays a list of categories and a list of tags.
+	 *
+	 * @since 1.2.0
 	 */
 	function understrap_categories_tags_list() {
 		understrap_categories_list();
@@ -90,6 +92,8 @@ if ( ! function_exists( 'understrap_categories_tags_list' ) ) {
 if ( ! function_exists( 'understrap_categories_list' ) ) {
 	/**
 	 * Displays a list of categories.
+	 *
+	 * @since 1.2.0
 	 */
 	function understrap_categories_list() {
 		$categories_list = get_the_category_list( understrap_get_list_item_separator() );
@@ -103,6 +107,8 @@ if ( ! function_exists( 'understrap_categories_list' ) ) {
 if ( ! function_exists( 'understrap_tags_list' ) ) {
 	/**
 	 * Displays a list of tags.
+	 *
+	 * @since 1.2.0
 	 */
 	function understrap_tags_list() {
 		$tags_list = get_the_tag_list( '', understrap_get_list_item_separator() );
@@ -116,6 +122,8 @@ if ( ! function_exists( 'understrap_tags_list' ) ) {
 if ( ! function_exists( 'understrap_comments_popup_link' ) ) {
 	/**
 	 * Displays the link to the comments for the current post.
+	 *
+	 * @since 1.2.0
 	 */
 	function understrap_comments_popup_link() {
 		if ( is_single() || post_password_required() || ( ! comments_open() && 0 === absint( get_comments_number() ) ) ) {
@@ -220,6 +228,8 @@ if ( ! function_exists( 'understrap_comment_navigation' ) ) {
 	/**
 	 * Displays the comment navigation.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @param string $nav_id The ID of the comment navigation.
 	 */
 	function understrap_comment_navigation( $nav_id ) {
@@ -252,6 +262,8 @@ if ( ! function_exists( 'understrap_comment_navigation' ) ) {
 if ( ! function_exists( 'understrap_edit_post_link' ) ) {
 	/**
 	 * Displays the edit post link for post.
+	 *
+	 * @since 1.0.0
 	 */
 	function understrap_edit_post_link() {
 		edit_post_link(
@@ -308,6 +320,8 @@ if ( ! function_exists( 'understrap_link_pages' ) ) {
 	 * `<!--nextpage-->` Quicktag one or more times). This tag must be
 	 * within The Loop. Default: echo.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @return void|string Formatted output in HTML.
 	 */
 	function understrap_link_pages() {
@@ -326,6 +340,8 @@ if ( ! function_exists( 'understrap_get_select_control_class' ) ) {
 	/**
 	 * Retrieves the Bootstrap CSS class for the select tag.
 	 *
+	 * @since 1.2.0
+	 *
 	 * @return string Bootstrap CSS class for the select tag.
 	 */
 	function understrap_get_select_control_class() {
@@ -342,6 +358,8 @@ if ( ! function_exists( 'understrap_get_list_item_separator' ) ) {
 	 *
 	 * `wp_get_list_item_separator()` has been introduced in WP 6.0.0. For WP
 	 * versions lower than 6.0.0 we have to use a custom translation.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @return string Localized list item separator.
 	 */

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -12,6 +12,8 @@ if ( ! function_exists( 'understrap_add_widget_categories_class' ) ) {
 	/**
 	 * Adds Bootstrap class to select tag in the Categories widget.
 	 *
+	 * @since 1.2.0
+	 *
 	 * @param array $cat_args An array of Categories widget drop-down arguments.
 	 * @return array The filtered array of Categories widget drop-down arguments.
 	 */
@@ -31,6 +33,8 @@ add_filter( 'widget_categories_dropdown_args', 'understrap_add_widget_categories
 if ( ! function_exists( 'understrap_add_block_widget_categories_class' ) ) {
 	/**
 	 * Adds Bootstrap class to select tag in the Categories block widget.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @param string $output      The taxonomy drop-down HTML output.
 	 * @param array  $parsed_args Arguments used to build the drop-down.
@@ -62,6 +66,8 @@ if ( ! function_exists( 'understrap_add_block_widget_archives_classes' ) ) {
 	/**
 	 * Adds Bootstrap class to select tag in the Archives widget.
 	 *
+	 * @since 1.2.0
+	 *
 	 * @param string $block_content The block content.
 	 * @param array  $block         The full block, including name and attributes.
 	 * @return string The filtered block content.
@@ -83,6 +89,8 @@ add_filter( 'render_block_core/archives', 'understrap_add_block_widget_archives_
 if ( ! function_exists( 'understrap_add_block_widget_search_classes' ) ) {
 	/**
 	 * Adds Bootstrap classes to search block widget.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @param string $block_content The block content.
 	 * @param array  $block         The full block, including name and attributes.
@@ -120,6 +128,8 @@ add_filter( 'render_block_core/search', 'understrap_add_block_widget_search_clas
 
 /**
  * Add active class to first item of carousel hero widget area.
+ *
+ * @since 1.2.0
  *
  * @param array $params {
  *     Parameters passed to a widget’s display callback.

--- a/loop-templates/content-author.php
+++ b/loop-templates/content-author.php
@@ -3,6 +3,7 @@
  * Template for displaying posts on the author archive
  *
  * @package Understrap
+ * @since 1.0.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
## Description
This PR adds since tags to file and function comments for changes in Understrap version 1.0.0, 1.0.1, 1.1.0, 1.2.0.

## Motivation and Context
Improve inline documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
No code change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.
