### PR TITLE
Fix sanitize_callback for the container type setting and the navbar type setting

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -142,18 +142,18 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 				$wp_customize,
 				'understrap_navbar_type',
 				array(
-					'label'             => __( 'Responsive Navigation Type', 'understrap' ),
-					'description'       => __(
+					'label'       => __( 'Responsive Navigation Type', 'understrap' ),
+					'description' => __(
 						'Choose between an expanding and collapsing navbar or an offcanvas drawer.',
 						'understrap'
 					),
-					'section'           => 'understrap_theme_layout_options',
-					'type'              => 'select',
-					'choices'           => array(
+					'section'     => 'understrap_theme_layout_options',
+					'type'        => 'select',
+					'choices'     => array(
 						'collapse'  => __( 'Collapse', 'understrap' ),
 						'offcanvas' => __( 'Offcanvas', 'understrap' ),
 					),
-					'priority'          => apply_filters( 'understrap_navbar_type_priority', 20 ),
+					'priority'    => apply_filters( 'understrap_navbar_type_priority', 20 ),
 				)
 			)
 		);
@@ -173,20 +173,20 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 				$wp_customize,
 				'understrap_sidebar_position',
 				array(
-					'label'             => __( 'Sidebar Positioning', 'understrap' ),
-					'description'       => __(
+					'label'       => __( 'Sidebar Positioning', 'understrap' ),
+					'description' => __(
 						'Set sidebar\'s default position. Can either be: right, left, both or none. Note: this can be overridden on individual pages.',
 						'understrap'
 					),
-					'section'           => 'understrap_theme_layout_options',
-					'type'              => 'select',
-					'choices'           => array(
+					'section'     => 'understrap_theme_layout_options',
+					'type'        => 'select',
+					'choices'     => array(
 						'right' => __( 'Right sidebar', 'understrap' ),
 						'left'  => __( 'Left sidebar', 'understrap' ),
 						'both'  => __( 'Left & Right sidebars', 'understrap' ),
 						'none'  => __( 'No sidebar', 'understrap' ),
 					),
-					'priority'          => apply_filters( 'understrap_sidebar_position_priority', 20 ),
+					'priority'    => apply_filters( 'understrap_sidebar_position_priority', 20 ),
 				)
 			)
 		);

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -132,7 +132,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 			array(
 				'default'           => 'collapse',
 				'type'              => 'theme_mod',
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => 'understrap_customize_sanitize_select',
 				'capability'        => 'edit_theme_options',
 			)
 		);
@@ -149,7 +149,6 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 					),
 					'section'           => 'understrap_theme_layout_options',
 					'type'              => 'select',
-					'sanitize_callback' => 'understrap_customize_sanitize_select',
 					'choices'           => array(
 						'collapse'  => __( 'Collapse', 'understrap' ),
 						'offcanvas' => __( 'Offcanvas', 'understrap' ),
@@ -164,7 +163,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 			array(
 				'default'           => 'right',
 				'type'              => 'theme_mod',
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => 'understrap_customize_sanitize_select',
 				'capability'        => 'edit_theme_options',
 			)
 		);
@@ -181,7 +180,6 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 					),
 					'section'           => 'understrap_theme_layout_options',
 					'type'              => 'select',
-					'sanitize_callback' => 'understrap_customize_sanitize_select',
 					'choices'           => array(
 						'right' => __( 'Right sidebar', 'understrap' ),
 						'left'  => __( 'Left sidebar', 'understrap' ),


### PR DESCRIPTION
## Description
This PR
* removes the `sanitize_callback` argument from `WP_Customize_Control` which [does not have such an argument](https://developer.wordpress.org/reference/classes/wp_customize_control/__construct/#parameters).
* sets `understrap_customize_sanitize_select` to be the `sanitize_callback` when adding the setting.

## Motivation and Context
Misplacement of the `sanitize_callback => 'understrap_customize_sanitize_select'`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.
