### PR TITLE
switch to monthly dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,7 @@ updates:
     open-pull-requests-limit: 10
     rebase-strategy: auto
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
+      interval: "monthly"
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
@@ -23,9 +21,7 @@ updates:
     open-pull-requests-limit: 10
     rebase-strategy: auto
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
+      interval: "monthly"
     target-branch: "develop"
     versioning-strategy: increase
 
@@ -40,8 +36,6 @@ updates:
     open-pull-requests-limit: 10
     rebase-strategy: auto
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
+      interval: "monthly"
     target-branch: "develop"
     versioning-strategy: increase


### PR DESCRIPTION
## Description
This PR changes the dependabot interval from weekly to monthly. 

## Motivation and Context
Reduce noise in the PR history. Ex.: https://github.com/understrap/understrap/pulls?page=6&q=is%3Apr+is%3Aclosed