### PR TITLE
Update Woocommerce templates

### DIFF
--- a/woocommerce/cart/cart-empty.php
+++ b/woocommerce/cart/cart-empty.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.8.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/cart/proceed-to-checkout-button.php
+++ b/woocommerce/cart/proceed-to-checkout-button.php
@@ -14,7 +14,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 2.4.0
+ * @version 7.0.1
  */
 
 // Exit if accessed directly.

--- a/woocommerce/checkout/form-coupon.php
+++ b/woocommerce/checkout/form-coupon.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.4
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/checkout/form-pay.php
+++ b/woocommerce/checkout/form-pay.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 5.2.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/checkout/payment.php
+++ b/woocommerce/checkout/payment.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.3
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/global/form-login.php
+++ b/woocommerce/global/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.6.0
+ * @version 7.0.1
  */
 
 // Exit if accessed directly.

--- a/woocommerce/global/form-login.php
+++ b/woocommerce/global/form-login.php
@@ -35,7 +35,7 @@ if ( is_user_logged_in() ) {
 	</p>
 	<p class="form-row form-row-last">
 		<label for="password"><?php esc_html_e( 'Password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
-		<input class="input-text form-control" type="password" name="password" id="password" autocomplete="current-password" />
+		<input class="input-text woocommerce-Input form-control" type="password" name="password" id="password" autocomplete="current-password" />
 	</p>
 	<div class="clear"></div>
 

--- a/woocommerce/myaccount/form-edit-account.php
+++ b/woocommerce/myaccount/form-edit-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/myaccount/form-edit-address.php
+++ b/woocommerce/myaccount/form-edit-address.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.6.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/myaccount/form-login.php
+++ b/woocommerce/myaccount/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 6.0.0
+ * @version 7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/woocommerce/myaccount/form-lost-password.php
+++ b/woocommerce/myaccount/form-lost-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.2
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/myaccount/form-reset-password.php
+++ b/woocommerce/myaccount/form-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.5
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/myaccount/orders.php
+++ b/woocommerce/myaccount/orders.php
@@ -14,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.7.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.3.0
+ * @version 7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/woocommerce/single-product/add-to-cart/simple.php
+++ b/woocommerce/single-product/add-to-cart/simple.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/woocommerce/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -4,7 +4,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
## Description
This PR updates the version number in Woocommerce templates.

## Motivation and Context
WooCommerce 7.0.1 adds `wc_wp_theme_get_element_class_name()` which is a wrapper for `wp_theme_get_element_class_name()` which calls `WP_Theme_JSON::get_element_class_name()`. Understrap does not come with a theme.json. Therefor a call to `WP_Theme_JSON::get_element_class_name( $element )` gives an empty string and adding `wc_wp_theme_get_element_class_name()` to the templates can be skipped (would be a breaking change).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issues or Roadmap requests
#1997
