### PR TITLE
Echo featured image conditionally

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -371,3 +371,22 @@ if ( ! function_exists( 'understrap_get_list_item_separator' ) ) {
 		return esc_html__( ', ', 'understrap' );
 	}
 }
+
+if ( ! function_exists( 'understrap_the_post_thumbnail' ) ) {
+	/**
+	 * Displays the post thumbnail if the Post Featured Image Block is not used
+	 * for a given post.
+	 *
+	 * @param string|int[]                     $size Image size.
+	 * @param string|array<string,string|bool> $attr Query string or array of attributes.
+	 */
+	function understrap_the_post_thumbnail( $size = 'post-thumbnail', $attr = '' ) {
+		global $wp_version;
+		if (
+			version_compare( $wp_version, '5.8' ) === -1 ||
+			! has_block( 'core/post-featured-image' )
+		) {
+			the_post_thumbnail( $size, $attr );
+		}
+	}
+}

--- a/loop-templates/content-page.php
+++ b/loop-templates/content-page.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 		);
 	}
 
-	echo get_the_post_thumbnail( $post->ID, 'large' );
+	understrap_the_post_thumbnail( 'large' );
 	?>
 
 	<div class="entry-content">

--- a/loop-templates/content-single.php
+++ b/loop-templates/content-single.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
 
 	</header><!-- .entry-header -->
 
-	<?php echo get_the_post_thumbnail( $post->ID, 'large' ); ?>
+	<?php understrap_the_post_thumbnail( 'large' ); ?>
 
 	<div class="entry-content">
 

--- a/loop-templates/content.php
+++ b/loop-templates/content.php
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 
 	</header><!-- .entry-header -->
 
-	<?php echo get_the_post_thumbnail( $post->ID, 'large' ); ?>
+	<?php understrap_the_post_thumbnail( 'large' ); ?>
 
 	<div class="entry-content">
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -55,3 +55,4 @@ parameters:
 		- '#Function understrap_tags_list\(\) has no return type specified.#'
 		- '#Function understrap_comments_popup_link\(\) has no return type specified.#'
 		- '#Function understrap_offcanvas_admin_bar_inline_styles\(\) has no return type specified.#'
+		- '#Function understrap_the_post_thumbnail\(\) has no return type specified.#'


### PR DESCRIPTION
## Description
This PR wraps `the_post_thumbnail()` in `understrap_the_post_thumbnail()` which checks for WP version and the presence of the Post Featured Image block before echoing the featured image,

## Motivation and Context
The [Post Featured Image block](https://wordpress.org/support/article/post-featured-image-block/) was introduced in WP 5.8. While it is intended to primarily be nested inside a query loop block it can be used in single posts and pages as well. The block requires a featured image to be set. If the block is used in single posts or pages the featured image is displayed twice because Understrap's content template already adds a featured image.

![image](https://user-images.githubusercontent.com/42134098/202321838-032f3bfe-3604-4acb-8c2c-964ac40cc537.png)

First checking whether the block is present gives a single image.

![image](https://user-images.githubusercontent.com/42134098/202322176-34aad8f8-47ac-48b9-a160-e4662e816a26.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (a code change that neither fixes a bug nor adds a feature)
- [ ] Styling (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Development (changes that affect the build system or external dependencies)
- [ ] Documentation (changes that affect existing inline documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer phpcs` has passed locally.
- [x] `composer php-lint` has passed locally.
- [x] `composer phpmd` has passed locally.
- [x] `composer phpstan` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
Would be good to check other blocks (post navigation, post date...) as well.
