### PR TITLE
Improve readability of sidebar templates

### DIFF
--- a/sidebar-templates/sidebar-footerfull.php
+++ b/sidebar-templates/sidebar-footerfull.php
@@ -8,27 +8,25 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-$container = get_theme_mod( 'understrap_container_type' );
+if ( ! is_active_sidebar( 'footerfull' ) ) {
+	return;
+}
 
+$container = get_theme_mod( 'understrap_container_type' );
 ?>
 
-<?php if ( is_active_sidebar( 'footerfull' ) ) : ?>
+<!-- ******************* The Footer Full-width Widget Area ******************* -->
 
-	<!-- ******************* The Footer Full-width Widget Area ******************* -->
+<div class="wrapper" id="wrapper-footer-full" role="complementary">
 
-	<div class="wrapper" id="wrapper-footer-full" role="complementary">
+	<div class="<?php echo esc_attr( $container ); ?>" id="footer-full-content" tabindex="-1">
 
-		<div class="<?php echo esc_attr( $container ); ?>" id="footer-full-content" tabindex="-1">
+		<div class="row">
 
-			<div class="row">
-
-				<?php dynamic_sidebar( 'footerfull' ); ?>
-
-			</div>
+			<?php dynamic_sidebar( 'footerfull' ); ?>
 
 		</div>
 
-	</div><!-- #wrapper-footer-full -->
+	</div>
 
-	<?php
-endif;
+</div><!-- #wrapper-footer-full -->

--- a/sidebar-templates/sidebar-hero.php
+++ b/sidebar-templates/sidebar-hero.php
@@ -7,37 +7,36 @@
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+if ( ! is_active_sidebar( 'hero' ) ) {
+	return;
+}
 ?>
 
-<?php if ( is_active_sidebar( 'hero' ) ) : ?>
+<!-- ******************* The Hero Widget Area ******************* -->
 
-	<!-- ******************* The Hero Widget Area ******************* -->
+<div id="carouselExampleControls" class="carousel slide" data-interval="false" data-bs-ride="false">
 
-	<div id="carouselExampleControls" class="carousel slide" data-interval="false" data-bs-ride="false">
+	<div class="carousel-inner">
 
-		<div class="carousel-inner">
+		<?php dynamic_sidebar( 'hero' ); ?>
 
-			<?php dynamic_sidebar( 'hero' ); ?>
+	</div>
 
-		</div>
+	<a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev" data-bs-slide="prev">
 
-		<a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev" data-bs-slide="prev">
+		<span class="carousel-control-prev-icon" aria-hidden="true"></span>
 
-			<span class="carousel-control-prev-icon" aria-hidden="true"></span>
+		<span class="screen-reader-text"><?php echo esc_html_x( 'Previous', 'carousel control', 'understrap' ); ?></span>
 
-			<span class="screen-reader-text"><?php echo esc_html_x( 'Previous', 'carousel control', 'understrap' ); ?></span>
+	</a>
 
-		</a>
+	<a class="carousel-control-next" href="#carouselExampleControls" role="button" data-slide="next" data-bs-slide="next">
 
-		<a class="carousel-control-next" href="#carouselExampleControls" role="button" data-slide="next" data-bs-slide="next">
+		<span class="carousel-control-next-icon" aria-hidden="true"></span>
 
-			<span class="carousel-control-next-icon" aria-hidden="true"></span>
+		<span class="screen-reader-text"><?php echo esc_html_x( 'Next', 'carousel control', 'understrap' ); ?></span>
 
-			<span class="screen-reader-text"><?php echo esc_html_x( 'Next', 'carousel control', 'understrap' ); ?></span>
+	</a>
 
-		</a>
-
-	</div><!-- .carousel -->
-
-	<?php
-endif;
+</div><!-- .carousel -->

--- a/sidebar-templates/sidebar-statichero.php
+++ b/sidebar-templates/sidebar-statichero.php
@@ -8,26 +8,25 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+if ( ! is_active_sidebar( 'statichero' ) ) {
+	return;
+}
+
 $container = get_theme_mod( 'understrap_container_type' );
 ?>
 
-<?php if ( is_active_sidebar( 'statichero' ) ) : ?>
+<!-- ******************* The Hero Widget Area ******************* -->
 
-	<!-- ******************* The Hero Widget Area ******************* -->
+<div class="wrapper" id="wrapper-static-hero">
 
-	<div class="wrapper" id="wrapper-static-hero">
+	<div class="<?php echo esc_attr( $container ); ?>" id="wrapper-static-content" tabindex="-1">
 
-		<div class="<?php echo esc_attr( $container ); ?>" id="wrapper-static-content" tabindex="-1">
+		<div class="row">
 
-			<div class="row">
-
-				<?php dynamic_sidebar( 'statichero' ); ?>
-
-			</div>
+			<?php dynamic_sidebar( 'statichero' ); ?>
 
 		</div>
 
-	</div><!-- #wrapper-static-hero -->
+	</div>
 
-	<?php
-endif;
+</div><!-- #wrapper-static-hero -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR moves the sidebar active check to the top of the file to increase readability.

## Motivation and Context
Returning early reduces complexity and increases readability. In the footerfull case and the statichero case this pattern even save a call to `get_theme_mod( 'understrap_container_type' )` if the corresponding sidebar is not active.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (a code change that neither fixes a bug nor adds a feature)
- [ ] Styling (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Development (changes that affect the build system or external dependencies)
- [ ] Documentation (changes that affect existing inline documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer phpcs` has passed locally.
- [x] `composer php-lint` has passed locally.
- [x] `composer phpmd` has passed locally.
- [x] `composer phpstan` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Further comments
It's not immediately apparent in the diff but the actual sidebar code has not changed at all.
