### PR TITLE
Fix TinyMCE body margin

### DIFF
--- a/inc/editor.php
+++ b/inc/editor.php
@@ -82,6 +82,18 @@ if ( ! function_exists( 'understrap_tiny_mce_before_init' ) ) {
 		}
 
 		$settings['style_formats'] = wp_json_encode( $style_formats );
+
+		/*
+		 * Fix TinyMCE editor body margin that is set to 0 by Bootstrap's
+		 * _reboot.scss (v4 & v5). `margin: 9px 10px` is the value used by WP's
+		 * TinyMCE skin (/wp-includes/js/tinymce/skins/wordpress/wp-content.css).
+		 */
+		if ( isset( $settings['content_style'] ) ) {
+			$settings['content_style'] .= ' body#tinymce { margin: 9px 10px; }';
+		} else {
+			$settings['content_style'] = 'body#tinymce { margin: 9px 10px; }';
+		}
+
 		return $settings;
 	}
 }


### PR DESCRIPTION
## Description
This PR adds inline CSS to the TinyMCE editor's `<body>` that adds margin.

## Motivation and Context
Understrap includes _reboot.scss in the custom editor styles. For both [v4](https://github.com/understrap/understrap/blob/546b350b62c22d384a563a9c0ad1b77f2331e046/src/sass/assets/bootstrap4/_reboot.scss#L47) and [v5](https://github.com/understrap/understrap/blob/546b350b62c22d384a563a9c0ad1b77f2331e046/src/sass/assets/bootstrap5/_reboot.scss#L50) _reboot.scss resets body margin from `margin: 9px 10px` ([WPs skin for TinyMCE](https://github.com/WordPress/WordPress/blob/15af7662df05a3e3b7b5818b05dde678c2bab708/wp-includes/js/tinymce/skins/wordpress/wp-content.css#L17)) to `margin: 0` resulting in missing body margin for all TinyMCE editor instances.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (a code change that neither fixes a bug nor adds a feature)
- [ ] Styling (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Development (changes that affect the build system or external dependencies)
- [ ] Documentation (changes that affect existing inline documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer phpcs` has passed locally.
- [x] `composer php-lint` has passed locally.
- [x] `composer phpmd` has passed locally.
- [x] `composer phpstan` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests
Fixes #2029
Fixes #2072
