### PR TITLE
Add grouped version updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     rebase-strategy: auto
     schedule:
       interval: "monthly"
+    target-branch: "develop"
+    groups:
+      github-actions:
+        patterns:
+        - "*"
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
@@ -24,6 +29,19 @@ updates:
       interval: "monthly"
     target-branch: "develop"
     versioning-strategy: increase
+    groups:
+      npm-assets:
+        patterns:
+        - "bootstrap*"
+        - "*popper*"
+        - "font-awesome"
+      npm-build:
+        patterns:
+        - "*"
+        exclude-patterns:
+        - "bootstrap*"
+        - "*popper*"
+        - "font-awesome"
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
@@ -39,3 +57,7 @@ updates:
       interval: "monthly"
     target-branch: "develop"
     versioning-strategy: increase
+    groups:
+      composer:
+        patterns:
+        - "*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the [configuration option "groups"](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) to the dependabot config file. This tells dependabot to not open PRs for each individual dependency but for the defined groups that are:
- all updates to Composer packages (group "composer")
- updates to Bootstrap, popper.js and Font Awesome (group "npm-assets")
- updates to all other npm packages (group "npm-build")
- all updates to Github Actions (group "github-actions")

## Motivation and Context
Grouping dependency updates reduces PR noise. Instead of
![image](https://github.com/understrap/understrap/assets/42134098/c2d6e94f-f5b0-4c58-97fd-9126c499096a)
we should see something like this
![image](https://github.com/understrap/understrap/assets/42134098/ada57a2e-d7b9-458c-88ea-d294ff4f32ee)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (a code change that neither fixes a bug nor adds a feature)
- [ ] Styling (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [x] Development (changes that affect the build system or external dependencies)
- [ ] Documentation (changes that affect existing inline documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [ ] `composer phpcs` has passed locally.
- [ ] `composer php-lint` has passed locally.
- [ ] `composer phpmd` has passed locally.
- [ ] `composer phpstan` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.
